### PR TITLE
Make parent process pass stdin into child

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -2,7 +2,7 @@
 
 var npm = require('npm');
 var path = require('path');
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var appModule = require('app-module-path');
 var fs = require('fs');
 var Q = require('q');
@@ -78,13 +78,12 @@ function generator() {
 // Run a command and pipe the output.
 // The returned promise will reject if there is a non-zero exist status
 function runCommand(cmd, args) {
-  var params = args ? ' ' + args.join(' ') : '';
-  var command = cmd + params;
-  var child = exec(command, { cwd: process.cwd() });
-  var deferred = Q.defer();
+  var child = spawn(cmd, args, {
+    cwd: process.cwd(),
+    stdio: 'inherit'
+  });
 
-  child.stdout.pipe(process.stdout);
-  child.stderr.pipe(process.stderr);
+  var deferred = Q.defer();
 
   child.on('exit', function(status) {
     if(status !== 0) {
@@ -110,7 +109,7 @@ if(commands[command]) {
     var pkg = require(path.join(process.cwd(), 'package.json'));
 
     if(pkg.scripts[command]) {
-      log(runCommand('npm run ' + command));
+      log(runCommand('npm', ['run', command]));
     } else {
       // If the command is not supported try running node_modules/.bin/donejs-command
       // with all the parameters
@@ -120,7 +119,7 @@ if(commands[command]) {
         return process.exit(1);
       }
 
-      var promise = runCommand(cmd, parameters.slice(3, parameters.length))();
+      var promise = runCommand(cmd, parameters.slice(3, parameters.length));
       log(promise);
     }
   } catch(e) {


### PR DESCRIPTION
This makes it so that the child process can use stdin. Using the `stdio:
'inherit'` option will fix this, but we have to use `spawn` rather than
`exec`.