### PR TITLE
Upgrade to steal/tools 0.12.0-pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
       "can-ssr": "^0.5.8",
       "done-autorender": "^0.4.0",
       "done-component": "^0.2.0",
-      "done-css": "~1.1.7",
+      "done-css": "~1.1.8",
       "generator-donejs": "^0.2.9",
       "jquery": "~2.1.4",
-      "steal": "^0.11.0-pre.8",
+      "steal": "^0.12.0-pre.0",
       "yeoman-environment": "~1.2.7"
     },
     "devDependencies": {
@@ -66,7 +66,7 @@
       "donejs-deploy": "^0.1.6",
       "funcunit": "~3.0.0",
       "steal-qunit": "^0.1.1",
-      "steal-tools": "^0.11.0-pre.11",
+      "steal-tools": "^0.12.0-pre.0",
       "testee": "^0.2.0"
     }
   }


### PR DESCRIPTION
This upgrades us to the latest version of Steal, StealTools, and
done-css that solves the problem outlined in #47.