### PR TITLE
Support 1 argument for installIfMissing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,10 @@ var yeoman = require('yeoman-environment');
 // if it is not available in the current path
 var installIfMissing = exports.installIfMissing = function(root, module) {
   var location = module ? path.join(root, module) : root;
+  if(!module) {
+    module = root;
+  }
+
   return function (previous) {
     try {
       require.resolve(location);


### PR DESCRIPTION
The user might provide a single argument like
`installIfMissing('day-seconds')` and we should support that. So we just
need to do some typical argument checking. Fixes #78