### PR TITLE
Adding steal-platform as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mkdirp": "^0.5.1",
     "npm": "^2.13.1",
     "q": "^1.4.1",
+    "steal-platform": "0.0.4",
     "yeoman-environment": "^1.2.7"
   },
   "directories": {


### PR DESCRIPTION
It's a very small module with no dependencies so little reason not to
make it more convenient for users. Fixes #90