### PR TITLE
fixes #197

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -93,7 +93,6 @@ Then you run the build. A build time algorithm analyzes the application's depend
 That's it! No need for additional configuration in your JavaScript.
 
 <a class="btn" href="http://stealjs.com/docs/steal-tools.guides.progressive_loading.html"><span>View the Documentation</span></a>
-
 <a class="btn" href="/Guide.html#section=section_Switchbetweenpages"><span>View the Guide</span></a>
 
 _Progressive Loading is a feature of [StealJS](http://stealjs.com/) with additional support via the [`<can-import>` tag](http://canjs.com/2.3-pre/docs/can%7Cview%7Cstache%7Csystem.import.html) of [CanJS](http://canjs.com/)_


### PR DESCRIPTION
Fixes @197

@moschel Here's the solution to the buttons not floating or displaying inline.  We simply remove the extra line break.  

I did research this to see if there was CSS solution to allow for situations like this.  However, CSS3 does not allow you to select a parent, which is what we would need to say. That is to come in CSS4.  That said, the only solution is to use JQuery.

Otherwise, we can just leave this with the idea that this should be _expected_ because that is what Markdown does when you add a line break, it wraps the element in a `<p>` tag.  So, we would actually be overwriting Markdown to solve for this problem.
