### PR TITLE
Add a guide on OS-specific prereqs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,6 +20,8 @@ If you run into any problems, let us know [on Gitter](https://gitter.im/donejs/d
 
 ## Setup
 
+*Before getting started you might want to check out the [OperatingSystems] guide to make sure you have all of the prerequisites.*
+
 In this section, we will install DoneJS and generate a new application. To get started, let's install the DoneJS command line utility globally:
 
 ```

--- a/docs/operating-systems.md
+++ b/docs/operating-systems.md
@@ -1,0 +1,89 @@
+@page OperatingSystems Operating Systems
+@parent DoneJS
+@hide sidebar
+@outline 2 ol
+@description This page contains operating system specific information needed use DoneJS.
+
+@body
+
+## Windows
+
+### Prerequisites
+
+This will help you get set up with DoneJS on Windows. To use DoneJS you need a C++ compiler (for native dependencies). First you need a recent version of [Node.js](https://nodejs.org/en/). DoneJS officially supports Node 0.10.x, 0.12.x, and IOjs, but more recent versions will likely work as well.
+
+#### Package Management
+
+In this guide we'll use [chocolatey](https://chocolatey.org/) to install packages needed. You don't have to use chocolatey if you don't want, and can instead search for the dependencies and install them with a Windows installer, but we'll use chocolately because it makes things a bit easier.
+
+After you've installed chocolatey by following the instructions [on the homepage](https://chocolatey.org/) **open an administrative console** and proceed to the next step.
+
+#### Python 2.x
+
+Native dependencies in Node.js are installed with [node-gyp](https://github.com/nodejs/node-gyp) which uses Python as a build tool. It expects Python 2.x:
+
+```shell
+choco install python2 -y
+```
+
+#### Windows SDK
+
+Next we need the Windows SDK. We're going to assume Windows 7, but adjust this command to the version of Windows you use:
+
+```shell
+choco install windows-sdk-7.1 -y
+```
+
+#### Visual Studio Express
+
+Installing Visual Studio Express gives us the C++ compiler we need:
+
+```shell
+choco install visualstudioexpress2013windowsdesktop -y
+```
+
+### Environmental Variables
+
+In order to switch to production mode you need to set the environmental variable `NODE_ENV`. Depending on which console you use this can be done in one of two ways:
+
+**Command Prompt**
+
+```
+set NODE_ENV=production
+```
+
+**Powershell**
+
+```
+$env:NODE_ENV="production"
+```
+
+## Debian / Ubuntu
+
+Installing in a Debian / Ubuntu environment takes a little extra work because the version of Node shipped is older than what is supported by DoneJS (and most other Node-based software).
+
+### Prerequisites
+
+Instead of installing Node.js from the repository we recommend using a PPA (a repostiroy maintained by a 3rd party). First get a copy of `curl` if you don't already have it:
+
+```
+sudo apt-get install curl
+```
+
+Then add the PPA to your source list:
+
+```
+curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
+```
+
+Install Node.js:
+
+```
+sudo apt-get install nodejs
+```
+
+It's important to also install the `build-essential` package afterwards. This will provide you the C++ compiler needed to build the native dependencies:
+
+```
+sudo apt-get install build-essential
+```


### PR DESCRIPTION
This guide is mostly to aid Windows users (and users of other operating
    systems) on things needed to get started. In the case of Windows
several utilities are needed to get a C++ compiler before you start
installing donejs. This is part of #162.

Closes #88
