### PR TITLE
Fixes #277 Error on homepage.

### DIFF
--- a/docs/theme/static/static.js
+++ b/docs/theme/static/static.js
@@ -508,9 +508,11 @@ steal("./content_list.js",
           });
         });
         $(function () {
-          $('#js-matrix-legend-affix').affix({
-            offset: { top: $('#js-matrix-legend-affix').offset().top }
-          });
+          if($('#js-matrix-legend-affix').length){
+            $('#js-matrix-legend-affix').affix({
+              offset: { top: $('#js-matrix-legend-affix').offset().top }
+            });  
+          }
         })
 
     });


### PR DESCRIPTION
Since the $('#js-matrix-legend-affix') element doesn't exist on the home page, $('#js-matrix-legend-affix').offset() is undefined.  This makes sure the element exists on the page before trying to use it.
