### PR TITLE
donejs init should run generator-donejs

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -35,7 +35,7 @@ utils.projectRoot().then(function (root) {
       }
 
       root = path.join(process.cwd(), 'node_modules');
-      log(utils.generate(root, ['app', {
+      log(utils.generate(root, 'generator-donejs', ['app', {
           version: mypkg.version,
           packages: mypkg.donejs
         }


### PR DESCRIPTION
donejs init is failing because the changes for `donejs add` changed the
signature of utils.generate, so bin/donejs needs to be updated so that
init uses `generator-donejs` as the generator.
