### PR TITLE
Fix an issue with generating permalinks for some sections

### DIFF
--- a/docs/theme/static/static.js
+++ b/docs/theme/static/static.js
@@ -353,7 +353,8 @@ steal("./content_list.js",
             if ( !this.id ) {
                 var tag = this.tagName.toLowerCase();
                 var prevTag = "h" + ( parseInt( tag.replace( /h(\d)/, "$1" ) ) - 1 );
-                var prevId = $( this ).prevAll( prevTag ).get( 0 ).id;
+                var prevEl = $( this ).prevAll( prevTag ).get( 0 );
+                var prevId = (prevEl) ? prevEl.id : '';
 
                 this.id = prevId + "__" + $( this ).text().replace( /[^a-z0-9]/gi, "" );
             }


### PR DESCRIPTION
Permalink’s are created for every section header. These permalinks include the ID of their parent header, but if there is no parent header (e.g. no h2 for an h3), the code would throw an error. This caused issues like the legend and tooltips not working for the framework comparison matrix.
