### PR TITLE
Do not use npm prefix, walk up looking for package.json instead

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,17 +54,18 @@ exports.spawn = function(cmd, args, options) {
 
 // Returns the NPM root
 exports.projectRoot = function() {
-  var deferred = Q.defer(),
-    child = cp.exec("npm prefix");
+  var root = process.cwd();
+  var current = root;
 
-  child.stdout.on("data", function(data) {
-    deferred.resolve(data.trim());
-  });
-  child.on("close", function(code) {
-    if (code) { deferred.reject(code); }
-  });
+  while(current && !fs.existsSync(path.join(current, 'package.json')) ) {
+    if(current !== path.dirname(current)) {
+      return Q(root);
+    }
 
-  return deferred.promise;
+    current = path.dirname(current);
+  }
+
+  return Q(current || root);
 };
 
 // Log error messages and exit application

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,11 +3,6 @@ var path = require('path');
 var fs = require('fs');
 var utils = require('../lib/utils');
 
-function fail(error) {
-  console.error(error.stack);
-  throw error;
-}
-
 describe('DoneJS CLI tests', function() {
   describe('utils', function() {
     it('mkdir recursively', function(done) {
@@ -22,13 +17,29 @@ describe('DoneJS CLI tests', function() {
       });
     });
 
-    it('get project root', function(done) {
-        var pathFromTest = path.join(process.cwd(), 'node_modules');
-        utils.projectRoot().then(function(p) {
-            assert.equal(path.join(p, 'node_modules'), pathFromTest);
-            done();
-        })
-        .fail(fail);
+    describe('project root', function() {
+      it('get project root when it is current folder', function(done) {
+          var pathFromTest = process.cwd();
+          utils.projectRoot().then(function(p) {
+              assert.equal(p, pathFromTest);
+              done();
+          })
+          .fail(done);
+      });
+
+      it('return cwd when there is no package.json anywhere', function(done) {
+          var oldCwd = process.cwd();
+          var newCwd = path.join(process.cwd(), '..');
+
+          process.chdir(newCwd);
+
+          utils.projectRoot().then(function(p) {
+              assert.equal(p, newCwd);
+              process.chdir(oldCwd);
+              done();
+          })
+          .fail(done);
+      });
     });
   });
 });


### PR DESCRIPTION
This prevents us from having to spawn the `npm prefix` process and instead just uses `fs.existsSync` which is much faster.
