### PR TITLE
Matrix tooltips 307

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -126,7 +126,10 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-fair.svg">
             </td>
             <td>
-              <img data-toggle="popover" data-placement="right" data-html="true" data-content='Requires some <a href="http://reactjsnews.com/isomorphic-javascript-with-react-node" target="_blank">manual setup</a>' class="matrix-rating-icon" src="/static/img/icon-good.svg">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content='Requires some <a href="http://reactjsnews.com/isomorphic-javascript-with-react-node" target="_blank">manual setup</a>'>
+                <img class="matrix-rating-icon" src="/static/img/icon-good.svg">
+                <span class="asterisk"></span>
+              </div>
             </td>
           </tr>
           <tr>
@@ -221,7 +224,10 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
             </td>
             <td>
-              <img class="matrix-rating-icon" data-toggle="popover" data-placement="right" data-html="true" data-content='<a href="https://docs.angularjs.org/guide/ie" target="_blank">Supports IE9+</a>' src="/static/img/icon-very-good.svg">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<a href="https://docs.angularjs.org/guide/ie" target="_blank">Supports IE9+</a>'>
+                <img class="matrix-rating-icon" src="/static/img/icon-very-good.svg">
+                <span class="asterisk"></span>
+              </div>
             </td>
             <td>
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
@@ -333,7 +339,9 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
             </td>
             <td>
-              <img class="matrix-rating-icon" data-toggle="popover" data-placement="right" data-html="true" data-content='Coming in Angular 2' src="/static/img/icon-poor.svg">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Coming in Angular 2">
+                <img class="matrix-rating-icon" src="/static/img/icon-poor.svg"><span class="asterisk"></span>
+              </div>
             </td>
             <td>
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">

--- a/docs/features.md
+++ b/docs/features.md
@@ -358,7 +358,9 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
             </td>
             <td>
-              <img class="matrix-rating-icon" src="/static/img/icon-poor.svg">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="JSX <em>only</em> supports <a href='https://facebook.github.io/react/docs/jsx-gotchas.html#custom-html-attributes' target='_bank'>native HTML elements.</a>">
+                <img class="matrix-rating-icon" src="/static/img/icon-poor.svg"><span class="asterisk"></span>
+              </div>
             </td>
           </tr>
           <tr>
@@ -372,7 +374,9 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-very-good.svg">
             </td>
             <td>
-              <img class="matrix-rating-icon" src="/static/img/icon-very-good.svg">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="React is just the view layer. You'll need to implement your own MVVM architecture.">
+              <img class="matrix-rating-icon" src="/static/img/icon-fair.svg"><span class="asterisk"></span>
+              </div>
             </td>
           </tr>
           <tr>

--- a/docs/theme/static/styles/_shared_layout.less
+++ b/docs/theme/static/styles/_shared_layout.less
@@ -677,7 +677,7 @@ body:not(.donejs) {
 		background-color: transparent;
 	}
 	td, th {
-		&:last-child {
+		&:last-of-type {
 			border-right:0;
 		}
 	}
@@ -700,9 +700,6 @@ body:not(.donejs) {
 	.matrix-rating-icon {
 		width: 20px;
 		height: 20px;
-		&[data-toggle="popover"] {
-			cursor: help;
-		}
 	}
 	.arrow:before {
 		display: none; // removes bootstrap triangle
@@ -710,6 +707,24 @@ body:not(.donejs) {
 	.framework-logo {
 		max-width: 50px;
 		margin:0;
+	}
+	.has-popover {
+		cursor: help;
+		position: relative;
+		img.matrix-rating-icon {
+			margin-top: 0 !important;
+			margin-bottom: 0 !important;
+		}
+	}
+	.asterisk::after {
+		position:absolute;
+		font-size: 1.6em;
+		left: 0; right: 0; top: -10px; bottom:0;
+		padding-left: 40px;
+		text-align: center;
+		content: '*';
+		color: @logoColor;
+		font-weight: bold;
 	}
 }
 .matrix-legend {


### PR DESCRIPTION
- resolves issue #307 
- Added an asterisk and larger target area for tooltips.
- Added additional clarification/tooltips for React - custom html elements, and React - MVVM
  <img width="819" alt="screen shot 2015-10-27 at 3 34 02 pm" src="https://cloud.githubusercontent.com/assets/1000574/10770163/2e6d2f2a-7cc0-11e5-8e8b-0a28b7824f9a.png">
