### PR TITLE
Use spawn that also works on Windows

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -16,8 +16,8 @@ utils.projectRoot().then(function(root) {
       console.error('Could not find local DoneJS binary (' + donejsBinary + ')');
       return;
     }
-    args.unshift(donejsBinary);
-    return utils.spawn('node', args, { cwd: root });
+    
+    return utils.spawn(donejsBinary, args, { cwd: root });
   };
 
   // donejs init

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
-var cp = require('child_process');
 var Q = require('q');
+var spawn = require('cross-spawn-async');
 
 // Recursively make a directory
 exports.mkdirp = function(folder) {
@@ -37,7 +37,7 @@ exports.mkdirp = function(folder) {
 exports.spawn = function(cmd, args, options) {
   options.stdio = 'inherit';
 
-  var child = cp.spawn(cmd, args, options || { cwd: process.cwd() });
+  var child = spawn(cmd, args, options || { cwd: process.cwd() });
   var deferred = Q.defer();
 
   child.on('exit', function(status) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "commander": "^2.8.1",
+    "cross-spawn-async": "^2.0.0",
     "q": "^1.4.1"
   },
   "directories": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,6 +17,13 @@ describe('DoneJS CLI tests', function() {
       });
     });
 
+    it('spawns successfully', function(done) {
+      utils.spawn('npm', ['run', 'verify'], {}).then(function(child) {
+        assert.equal(child.exitCode, 0);
+        done();
+      });
+    });
+
     describe('project root', function() {
       it('get project root when it is current folder', function(done) {
           var pathFromTest = process.cwd();


### PR DESCRIPTION
Node's `spawn` can cause errors on Windows.
