### PR TITLE
Matrix table mobile

### DIFF
--- a/docs/community.mustache
+++ b/docs/community.mustache
@@ -15,7 +15,7 @@
                     <li>
                       <a href="https://gitter.im/donejs/donejs">
                         <img class="quick-link-icon" src="/static/img/icon-gittr-gray.svg">
-                        <span class="quick-link-label">Gitter</span>
+                        <span class="quick-link-label">Chat</span>
                       </a>
                     </li>
                     <li>

--- a/docs/features.md
+++ b/docs/features.md
@@ -123,12 +123,12 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
             </td>
             <td>
-              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Angular doesn't support a virtual dom. No third-party library support would be equivilant." title="Angular doesn't support a virtual dom. No third-party library support would be equivilant.">
+              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Angular doesn't support a virtual dom. No third-party library support would be equivalent." title="Angular doesn't support a virtual dom. No third-party library support would be equivalent.">
                 <img class="matrix-rating-icon" src="/static/img/icon-poor.svg"><span class="asterisk"></span>
               </div>
             </td>
             <td>
-              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Requires some <a href='http://reactjsnews.com/isomorphic-javascript-with-react-node' target='_blank'>manual setup</a> and lacks most of the features/support DoneJS has." title="Requires some manual setup and lacks most of the features/support DoneJS has.">
+              <div class="has-popover" data-container="matrix-wrapper" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Requires some <a href='http://reactjsnews.com/isomorphic-javascript-with-react-node' target='_blank'>manual setup</a> and lacks most of the features/support DoneJS has." title="Requires some manual setup and lacks most of the features/support DoneJS has.">
                 <img class="matrix-rating-icon" src="/static/img/icon-fair.svg"><span class="asterisk"></span>
               </div>
             </td>
@@ -380,12 +380,12 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-excellent.svg">
             </td>
             <td>
-            <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Not explicitly MVVM, but could be implemented" title="Not explicitly MVVM, but could be implemented">
+            <div class="has-popover" data-toggle="popover" data-placement="top" data-html="true" data-content="Not explicitly MVVM, but could be implemented" title="Not explicitly MVVM, but could be implemented">
                 <img class="matrix-rating-icon" src="/static/img/icon-very-good.svg"><span class="asterisk"></span>
               </div>
             </td>
             <td>
-              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="React is just the view layer. You'll need to implement your own MVVM architecture." title="React is just the view layer. You'll need to implement your own MVVM architecture.">
+              <div class="has-popover" data-toggle="popover" data-placement="top" data-html="true" data-content="React is just the view layer. You'll need to implement your own MVVM architecture." title="React is just the view layer. You'll need to implement your own MVVM architecture.">
                 <img class="matrix-rating-icon" src="/static/img/icon-good.svg"><span class="asterisk"></span>
               </div>
             </td>
@@ -401,7 +401,7 @@ Solving a story means a packaged solution to a development problem, where severa
               <img class="matrix-rating-icon" src="/static/img/icon-poor.svg">
             </td>
             <td>
-              <div class="has-popover" data-toggle="popover" data-placement="bottom" data-html="true" data-content="Third-party libraries available for some support." title="Third-party libraries available for some support.">
+              <div class="has-popover" data-toggle="popover" data-placement="top" data-html="true" data-content="Third-party libraries available for some support." title="Third-party libraries available for some support.">
                 <img class="matrix-rating-icon" src="/static/img/icon-fair.svg"><span class="asterisk"></span>
               </div>
             </td>

--- a/docs/theme/static/static.js
+++ b/docs/theme/static/static.js
@@ -516,7 +516,7 @@ steal("./content_list.js",
         $(function () {
           $('.matrix-table [data-toggle="popover"]').popover({
             viewport: {
-              selector: '.matrix-table'
+              selector: '.table-wrapper'
             },
             container: '.table-wrapper'
           });

--- a/docs/theme/static/static.js
+++ b/docs/theme/static/static.js
@@ -514,8 +514,14 @@ steal("./content_list.js",
         });
 
         $(function () {
-          $('[data-toggle="popover"]').popover()
-            .on('shown.bs.popover', function(ev){
+          $('.matrix-table [data-toggle="popover"]').popover({
+            viewport: {
+              selector: '.matrix-table'
+            },
+            container: '.table-wrapper'
+          });
+          $('[data-toggle="popover"]:not(.matrix-table [data-toggle="popover"])').popover();
+          $('[data-toggle="popover"]').on('shown.bs.popover', function(ev){
                 var popoverId = $(this).attr('aria-describedby');
                 $('#' + popoverId).find('.youtube-player').lazyYoutube();
             });

--- a/docs/theme/static/styles/_shared_layout.less
+++ b/docs/theme/static/styles/_shared_layout.less
@@ -775,11 +775,13 @@ body:not(.donejs):not(.community) {
 	z-index: 1060;
 	position: absolute;
 	right: ~"calc( ( 80% - " @containerWidth ~" ) / 2)";
-
 	&.affix {
 		top: 100px;
 		right: ~"calc( ( 80% - " @containerWidth ~" ) / 2)";
 		position: fixed;
+		@media(max-width:@screen-xs){
+			top: inherit;
+		}
 	}
 	.title {
 		background-color: @logoColor;
@@ -907,6 +909,11 @@ body:not(.donejs):not(.community) {
 	div.table-wrapper div.scrollable {
     overflow: scroll;
     overflow-y: hidden;
+	}
+	table.responsive {
+		@media(max-width:@screen-xs){
+			width: 64%;
+		}
 	}
 	table.responsive td,
 	table.responsive th {

--- a/docs/theme/static/styles/_shared_layout.less
+++ b/docs/theme/static/styles/_shared_layout.less
@@ -707,6 +707,16 @@ body:not(.donejs):not(.community) {
 		color: @logoColor;
 		font-weight: bold;
 	}
+	.popover {
+		@media(max-width: @screen-sm){
+			max-width: 200px
+		}
+	}
+	.arrow {
+		&:before {
+			display: none;
+		}
+	}
 }
 .matrix-table {
 	background-color: transparent;
@@ -911,7 +921,7 @@ body:not(.donejs):not(.community) {
     overflow-y: hidden;
 	}
 	table.responsive {
-		@media(max-width:@screen-xs){
+		@media(max-width:@screen-sm){
 			width: 64%;
 		}
 	}

--- a/docs/theme/static/styles/_shared_layout.less
+++ b/docs/theme/static/styles/_shared_layout.less
@@ -208,6 +208,8 @@ body:not(.donejs):not(.community) {
 				.fun-quotes {
 					padding: 20px 0;
 					color: #424a4e;
+					background: none;
+					border:0;
 					.fun-intro {
 						font-size: 18px;
 						font-weight: 400;

--- a/docs/theme/static/styles/variables-bootstrap-custom.less
+++ b/docs/theme/static/styles/variables-bootstrap-custom.less
@@ -271,8 +271,8 @@
 
 @zindex-navbar:            1000;
 @zindex-dropdown:          1000;
-@zindex-popover:           1060;
-@zindex-tooltip:           1070;
+@zindex-popover:           1090;
+@zindex-tooltip:           1090;
 @zindex-navbar-fixed:      1030;
 @zindex-modal-background:  1040;
 @zindex-modal:             1050;


### PR DESCRIPTION
Closes #413 

This PR condenses the comparison matrix table to fit the three columns into smaller viewports so that no horizontal scrolling is needed.  It keeps the responsive-tables.js functionality in-place, in case we add more columns and scrolling is needed.  It also resolves some issues where the popovers are tiny, or cut off by overflow or z-index issues with the fixed left table column.

![donejs-matrix-mobile](https://cloud.githubusercontent.com/assets/5687712/10919752/24ceec02-8232-11e5-9315-84d717c02417.gif)
