### PR TITLE
Add .cmd to donejs-cli script for Windows

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -10,7 +10,8 @@ var initDescription = 'Initialize a new DoneJS application in a new folder or th
 program.version(mypkg.version);
 
 utils.projectRoot().then(function(root) {
-  var donejsBinary = path.join(root, 'node_modules', '.bin', 'donejs');
+  var doneScript = process.platform === 'win32' ? 'donejs.cmd' : 'donejs';
+  var donejsBinary = path.join(root, 'node_modules', '.bin', doneScript);
   var runBinary = function(args) {
     if(!fs.existsSync(donejsBinary)) {
       console.error('Could not find local DoneJS binary (' + donejsBinary + ')');
@@ -32,7 +33,7 @@ utils.projectRoot().then(function(root) {
 
         return utils.spawn('npm', [ 'install', 'donejs-cli' ], options)
           .then(function() {
-            var args = [ 'node_modules', '.bin', 'donejs' ];
+            var args = [ 'node_modules', '.bin', doneScript ];
             var binary = path.join.apply(path, [fullPath].concat(args));
 
             if(!fs.existsSync(binary)) {


### PR DESCRIPTION
For some odd reason (it works when running with a local installation) `cross-spawn-async` doesn't seem to take care of finding the correct binary all the time. In some cases Windows needs the `.cmd` extension for the DoneJS binary. This may be the reason why the Windows guide automation keeps getting stuck but will have to verify.
