### PR TITLE
Use version of donejs-cli same as donejs

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -32,7 +32,9 @@ utils.projectRoot().then(function(root) {
         console.log('Initializing new DoneJS application at', fullPath);
         console.log('Installing donejs-cli');
 
-        return utils.spawn('npm', [ 'install', 'donejs-cli' ], options)
+        var cliArg = 'donejs-cli@' + utils.versionRange(mypkg.version);
+
+        return utils.spawn('npm', [ 'install', cliArg ], options)
           .then(function() {
             var args = [ 'node_modules', '.bin', doneScript ];
             var binary = path.join.apply(path, [fullPath].concat(args));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,3 +77,8 @@ exports.log = function(promise) {
     process.exit(1);
   });
 };
+
+// Takes an exact version like 0.5.7 and turns into a range like ^0.5.0
+exports.versionRange = function(exactVersion){
+  return "^" + exactVersion.substr(0, exactVersion.lastIndexOf(".")) + ".0";
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donejs",
-  "version": "0.5.7",
+  "version": "0.6.0-pre.0",
   "description": "Your app is done",
   "main": "index.js",
   "bin": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -48,5 +48,15 @@ describe('DoneJS CLI tests', function() {
           .fail(done);
       });
     });
+
+    describe('versionRange', function() {
+      it('gives a semver range compatible with the latest of a given version', function(){
+        assert.equal(
+          "^0.5.0",
+          utils.versionRange("0.5.12"),
+          "^0.5.0 is what you want if the current version of 0.5.12"
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
This changes it so that when you perform `donejs init` it will download
a version of donejs-cli that makes the version of donejs you are using.
That means if you are using donejs 0.6.0 it will download donejs-cli
^0.6.0. This is necessary so that people don't always get the most
recent version of donejs when they do an init.
