### PR TITLE
Launch donejs-cli from Node

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -34,20 +34,20 @@ utils.projectRoot().then(function(root) {
 
         return utils.spawn('npm', [ 'install', 'donejs-cli' ], options)
           .then(function() {
-            var args = [ 'node_modules', '.bin', doneScript ];
+            var args = [ 'node_modules', 'donejs-cli', 'bin', 'donejs' ];
             var binary = path.join.apply(path, [fullPath].concat(args));
-            var initArgs = ['init'];
-
+            
             if(!fs.existsSync(binary)) {
               // If donejs-cli wasn't installed in this folder, it is the root
               binary = path.join.apply(path, [root].concat(args));
             }
+            var initArgs = [binary, 'init'];
 
             if(opts.skipInstall) {
               args.push('--skip-install');
             }
 
-            return utils.spawn(binary, initArgs, options);
+            return utils.spawn('node', initArgs, options);
           });
       });
 


### PR DESCRIPTION
Instead of calling out to node_modules/.bin/donejs we are going to call out to "node node_modules/.bin/donejs". This is only for donejs init.

The reason is that on windows by calling out to donejs.cmd npm is unable to remove this file when it reinstalls donejs-cli.
