### PR TITLE
Launch donejs-cli from Node

### DIFF
--- a/bin/donejs
+++ b/bin/donejs
@@ -34,20 +34,20 @@ utils.projectRoot().then(function(root) {
 
         return utils.spawn('npm', [ 'install', 'donejs-cli' ], options)
           .then(function() {
-            var args = [ 'node_modules', '.bin', doneScript ];
+            var args = [ 'node_modules', 'donejs-cli', 'bin', 'donejs' ];
             var binary = path.join.apply(path, [fullPath].concat(args));
-            var initArgs = ['init'];
-
+            
             if(!fs.existsSync(binary)) {
               // If donejs-cli wasn't installed in this folder, it is the root
               binary = path.join.apply(path, [root].concat(args));
             }
+            var initArgs = [binary, 'init'];
 
             if(opts.skipInstall) {
               args.push('--skip-install');
             }
 
-            return utils.spawn(binary, initArgs, options);
+            return utils.spawn('node', initArgs, options);
           });
       });
 

--- a/bin/donejs
+++ b/bin/donejs
@@ -32,7 +32,9 @@ utils.projectRoot().then(function(root) {
         console.log('Initializing new DoneJS application at', fullPath);
         console.log('Installing donejs-cli');
 
-        return utils.spawn('npm', [ 'install', 'donejs-cli' ], options)
+        var cliArg = 'donejs-cli@' + utils.versionRange(mypkg.version);
+
+        return utils.spawn('npm', [ 'install', cliArg ], options)
           .then(function() {
             var args = [ 'node_modules', '.bin', doneScript ];
             var binary = path.join.apply(path, [fullPath].concat(args));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -77,3 +77,8 @@ exports.log = function(promise) {
     process.exit(1);
   });
 };
+
+// Takes an exact version like 0.5.7 and turns into a range like ^0.5.0
+exports.versionRange = function(exactVersion){
+  return "^" + exactVersion.substr(0, exactVersion.lastIndexOf(".")) + ".0";
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donejs",
-  "version": "0.5.7",
+  "version": "0.6.0-pre.0",
   "description": "Your app is done",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donejs",
-  "version": "0.6.0-pre.0",
+  "version": "0.6.0-pre.1",
   "description": "Your app is done",
   "main": "index.js",
   "bin": {

--- a/test/utils.js
+++ b/test/utils.js
@@ -48,5 +48,15 @@ describe('DoneJS CLI tests', function() {
           .fail(done);
       });
     });
+
+    describe('versionRange', function() {
+      it('gives a semver range compatible with the latest of a given version', function(){
+        assert.equal(
+          "^0.5.0",
+          utils.versionRange("0.5.12"),
+          "^0.5.0 is what you want if the current version of 0.5.12"
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Instead of calling out to node_modules/.bin/donejs we are going to call out to "node node_modules/.bin/donejs". This is only for donejs init.

The reason is that on windows by calling out to donejs.cmd npm is unable to remove this file when it reinstalls donejs-cli.

Fixes #453 
