### PR TITLE
Set the renderingBaseURL

### DIFF
--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -2116,7 +2116,7 @@ And also update the production `baseURL` in the `system` section:
   ...
   "envs": {
     "server-production": {
-      "baseURL": "https://<appname>.firebaseapp.com/"
+      "renderingBaseURL": "https://<appname>.firebaseapp.com/"
     }
   }
 }


### PR DESCRIPTION
This updates the guide to set the renderingBaseURL for CDN deployments.

Closes #554
