### PR TITLE
Wait for done-serve to start in prod check

### DIFF
--- a/guides/guide/test.js
+++ b/guides/guide/test.js
@@ -257,7 +257,7 @@ if(isWindowsCI) {
     var child = guide.canServe = guide.executeCommand("donejs", ["start"])
       .childProcess;
 
-    var server = streamWhen(child.stdout, /can-serve starting on/);
+    var server = streamWhen(child.stdout, /done-serve starting on/);
     return server.then(wait);
   });
 


### PR DESCRIPTION
This updates the chat guide test to wait for the string:

```
done-serve
```

To show up, rather than waiting for can-serve. This should fix the
tests.
