### PR TITLE
Fix highlighting offset and content in between-pages guide

### DIFF
--- a/docs/guides/guide.md
+++ b/docs/guides/guide.md
@@ -159,7 +159,7 @@ Finally, we'll glue both components together as separate pages in `src/index.sta
 Update `src/index.stache` to:
 
 @sourceref guides/guide/steps/7-navigate/index.stache
-@highlight 15-31
+@highlight 18-34
 
 Now each component is being dynamically loaded while navigating between the home and messages page.  You should see the changes already in your browser.
 

--- a/guides/guide/steps/7-navigate/index.stache
+++ b/guides/guide/steps/7-navigate/index.stache
@@ -10,6 +10,11 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-8 col-sm-offset-2">
+          <h1 class="page-header text-center">
+            <img src="http://donejs.com/static/img/donejs-logo-white.svg"
+                alt="DoneJS logo" style="width: 100%;" />
+            <br>Chat
+          </h1>
           {{#eq page 'chat'}}
             <can-import from="donejs-chat/messages/">
               {{#if isPending}}


### PR DESCRIPTION
For #629

Add missing header content to "Switch between pages" portion of the guide.
Fix highlighting offset.
