### PR TITLE
updates the guide and adds a blind test and fix for the guide test

### DIFF
--- a/docs/guides/guide.md
+++ b/docs/guides/guide.md
@@ -235,7 +235,7 @@ If you open [localhost:8080/chat](http://localhost:8080/chat), you will see a li
 
 ### Create messages
 
-Now let's add the form to create new messages. The form two-way binds the `name` and `body` properties to the component's view-model and calls `send()` when hitting the enter key in the message input. 
+Now let's add the form to create new messages. The form two-way binds the `name` and `body` properties to the component's view-model and calls `send()` when hitting the enter key in the message input.
 
 Update `src/messages/messages.stache` to look like this:
 
@@ -266,7 +266,7 @@ Right now our chat's messages update automatically with our own messages, but no
 To connect to it, first we'll install a socket.io connector, by running:
 
 ```
-npm install steal-socket.io --save
+npm install steal-socket.io@2 --save
 ```
 
 Update `src/models/message.js` to:

--- a/guides/guide/steps/12-real-time/test.js
+++ b/guides/guide/steps/12-real-time/test.js
@@ -1,0 +1,15 @@
+MinUnit.module("Adding messages");
+
+MinUnit.test("Can go to the chat page and add a message", function(done){
+	function some(size) { return size > 0; }
+
+	F("bit-tabs").exists("we are on the home page");
+	F(".btn-primary").click();
+
+	F("form input:eq(0)").click().type("DoneJS");
+	F("form input:eq(1)").click().type("Real Time Rocks");
+	F("form input:eq(2)").click();
+
+	F("message-model .list-group-item-text:contains('Real Time Rocks')").size(some, "Message added to the page");
+	F(done);
+});

--- a/guides/guide/test.js
+++ b/guides/guide/test.js
@@ -222,13 +222,17 @@ guide.test(function(){
  * @Step 12
  */
 guide.step("Enable a real-time connection", function(){
-	return guide.executeCommand("npm", ["install", "steal-socket.io", "--save"])
+	return guide.executeCommand("npm", ["install", "steal-socket.io@2", "--save"])
 		.then(wait)
 		.then(function(){
 			return guide.replaceFile(join("src", "models", "message.js"),
 									 join(__dirname, "steps", "12-real-time", "message.js"));
 		});
 
+});
+
+guide.test(function(){
+	return guide.functionalTest(join(__dirname, "steps", "12-real-time", "test.js"));
 });
 
 /**


### PR DESCRIPTION
For #765 


@matthewp I was getting this error when running locally:

```
Oh no Must provide a browser to run in Error: Must provide a browser to run in
    at Object.gt.openBrowser (/Users/justin/dev/donejs/node_modules/guide-automation/lib/guide-test.js:132:10)
    at /Users/justin/dev/donejs/node_modules/guide-automation/lib/guide-test.js:154:15
    at process._tickCallback (internal/process/next_tick.js:103:7) [Error: Must provide a browser to run in]
```

Let me know if you've got a quick solution.  Thanks!