### PR TITLE
Update PMO guide and test to use updated supermodel generator

### DIFF
--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -481,17 +481,22 @@ View models that are decoupled from the presentation layer are easy to test. We 
 Unit tests should be able to run by themselves without the need for an API server. This is where [fixtures](http://canjs.com/doc/can-fixture.html) come in. Fixtures allow us to mock requests to the REST API with data that we can use for tests or demo pages. Default fixtures will be provided for every generated model. Now we'll add more realistic fake data by updating `src/models/fixtures/states.js` to:
 
 @sourceref ../../guides/place-my-order/steps/create-test/states.js
-@highlight 3-6
+@highlight 4-7
 
 Update `src/models/fixtures/cities.js` to look like:
 
 @sourceref ../../guides/place-my-order/steps/create-test/cities.js
-@highlight 3-6
+@highlight 4-7
 
-And we also need to provide a restaurant list according to the selected city and state in `src/models/fixtures/restaurants.js`:
+Update `src/models/fixtures/restaurants.js` to look like:
 
 @sourceref ../../guides/place-my-order/steps/create-test/restaurants.js
-@highlight 3-36
+@highlight 4-30
+
+And we also need to specify that the restaurant list should be filtered to only restaurants in the selected city and state by updating `src/models/restaurants.js`:
+
+@sourceref ../../guides/place-my-order/steps/create-test/restaurants_model.js
+@highlight 15-22
 
 #### Test the view model
 
@@ -826,7 +831,6 @@ Now we can import that component and update `src/order/new/new.stache` to:
 This is a longer template so lets walk through it:
 
 - `<can-import from="place-my-order/order/details.component" />` loads the order details component we previously created
-- `<restaurant-model get="{ _id=slug }">` loads a restaurant based on the slug value passed to the component
 - If the `saveStatus` promise is resolved we show the `pmo-order-details` component with that order
 - Otherwise we will show the order form with the `bit-tabs` panels we implemented in the previous chapter and iterate over each menu item
 - `($submit)="placeOrder()"` will call `placeOrder` from our view model when the form is submitted
@@ -851,7 +855,12 @@ npm install steal-socket.io --save
 Update `src/models/order.js` to:
 
 @sourceref ../../guides/place-my-order/steps/real-time/order.js
-@highlight 6,72-76
+@highlight 6-7,74-78,80
+
+This:
+
+- uses socket.io to update the Order model in real-time
+- sets up [can-connect/can/tag/](http://canjs.com/doc/can-connect/can/tag/tag.html) so that the Order model can be used declaratively in the template like `<order-model get-list="{status='new'}">`
 
 ### Update the template
 

--- a/guides/place-my-order/steps/additional/details.component
+++ b/guides/place-my-order/steps/additional/details.component
@@ -2,11 +2,10 @@
   <view>
     <can-import from="place-my-order/models/restaurant" />
     <can-import from="can-stache/helpers/route" />
-    <restaurant-model get="{ _id=slug }">
-      {{#if isPending}}
-        <div class="loading"></div>
-      {{else}}
-      {{#value}}
+    {{#if restaurantPromise.isPending}}
+      <div class="loading"></div>
+    {{else}}
+      {{#restaurantPromise.value}}
       <div class="restaurant-header"
           style="background-image: url({{joinBase images.banner}});">
         <div class="background">
@@ -41,8 +40,17 @@
           </a>
         </p>
       </div>
-      {{/value}}
-      {{/if}}
-    </restaurant-model>
+      {{/restaurantPromise.value}}
+    {{/if}}
   </view>
+  <script type="view-model">
+    import DefineMap from 'can-define/map/';
+    import Restaurant from 'place-my-order/models/restaurant';
+
+    export default DefineMap.extend({
+      get restaurantPromise() {
+        return Restaurant.get({ _id: this.slug });
+      }
+    });
+  </script>
 </can-component>

--- a/guides/place-my-order/steps/create-data/order.js
+++ b/guides/place-my-order/steps/create-data/order.js
@@ -1,7 +1,7 @@
 import DefineMap from 'can-define/map/';
 import DefineList from 'can-define/list/';
+import set from 'can-set';
 import superMap from 'can-connect/can/super-map/';
-import tag from 'can-connect/can/tag/';
 import loader from '@loader';
 
 const Item = DefineMap.extend({
@@ -26,7 +26,7 @@ const ItemsList = DefineList.extend({
   }
 });
 
-export const Order = DefineMap.extend({
+const Order = DefineMap.extend({
   seal: false
 }, {
   '_id': '*',
@@ -53,18 +53,20 @@ export const Order = DefineMap.extend({
   }
 });
 
+const algebra = set.Algebra(
+  set.props.id('_id')
+);
+
 Order.List = DefineList.extend({
   '*': Order
 });
 
-export const orderConnection = superMap({
+Order.connection = superMap({
   url: loader.serviceBaseURL + '/api/orders',
-  idProp: '_id',
   Map: Order,
   List: Order.List,
-  name: 'order'
+  name: 'order',
+  algebra
 });
-
-tag('order-model', orderConnection);
 
 export default Order;

--- a/guides/place-my-order/steps/create-routes/app.js
+++ b/guides/place-my-order/steps/create-routes/app.js
@@ -3,9 +3,9 @@ import route from 'can-route';
 import 'can-route-pushstate';
 
 const AppViewModel = DefineMap.extend({
-  page: "string",
-  slug: "string",
-  action: "string",
+  page: 'string',
+  slug: 'string',
+  action: 'string',
 
   title: {
     value: 'place-my-order',

--- a/guides/place-my-order/steps/create-test/cities.js
+++ b/guides/place-my-order/steps/create-test/cities.js
@@ -1,16 +1,11 @@
 import fixture from 'can-fixture';
+import City from '../city';
 
 const store = fixture.store([
   { state: 'CA', name: 'Casadina' },
   { state: 'NT', name: 'Alberny' }
-],{});
+], City.connection.algebra);
 
-fixture({
-  'GET /api/cities': store.findAll,
-  'GET /api/cities/{name}': store.findOne,
-  'POST /api/cities': store.create,
-  'PUT /api/cities/{name}': store.update,
-  'DELETE /api/cities/{name}': store.destroy
-});
+fixture('/api/cities/{name}', store);
 
 export default store;

--- a/guides/place-my-order/steps/create-test/list_test.js
+++ b/guides/place-my-order/steps/create-test/list_test.js
@@ -12,7 +12,7 @@ QUnit.module('place-my-order/restaurant/list', {
 
 QUnit.asyncTest('loads all states', function() {
   var vm = new ViewModel();
-  var expectedStates = stateStore.getListData({});
+  var expectedStates = stateStore.getList({});
 
   vm.states.then(states => {
     QUnit.deepEqual(states.serialize(), expectedStates.data, 'Got all states');
@@ -22,7 +22,7 @@ QUnit.asyncTest('loads all states', function() {
 
 QUnit.asyncTest('setting a state loads its cities', function() {
   var vm = new ViewModel();
-  var expectedCities = cityStore.getListData({data: {state: "CA"}}).data;
+  var expectedCities = cityStore.getList({ state: "CA" }).data;
 
   QUnit.equal(vm.cities, null, '');
   vm.state = 'CA';
@@ -34,29 +34,29 @@ QUnit.asyncTest('setting a state loads its cities', function() {
 
 QUnit.asyncTest('changing a state resets city', function() {
   var vm = new ViewModel();
-  var expectedCities = cityStore.getListData({data: {state: "CA"}}).data;
+  var expectedCities = cityStore.getList({ state : "CA" }).data;
 
   QUnit.equal(vm.cities, null, '');
   vm.state = 'CA';
   vm.cities.then(cities => {
-    QUnit.deepEqual(cities.serialize(), expectedCities);
+    QUnit.deepEqual(cities.serialize(), expectedCities, 'Got all cities');
     vm.state = 'NT';
-    QUnit.equal(vm.city, null);
+    QUnit.equal(vm.city, null, 'City reset');
     QUnit.start();
   });
 });
 
 QUnit.asyncTest('setting state and city loads a list of its restaurants', function() {
   var vm = new ViewModel();
-  var expectedRestaurants = restaurantStore.getListData({
-    data: {"address.city": "Alberny"}
+  var expectedRestaurants = restaurantStore.getList({
+    "address.city": "Alberny"
   }).data;
 
   vm.state = 'NT';
   vm.city = 'Alberny';
 
   vm.restaurants.then(restaurants => {
-    QUnit.deepEqual(restaurants.serialize(), expectedRestaurants);
+    QUnit.deepEqual(restaurants.serialize(), expectedRestaurants, 'Got all restaurants');
     QUnit.start();
   });
 });

--- a/guides/place-my-order/steps/create-test/restaurants.js
+++ b/guides/place-my-order/steps/create-test/restaurants.js
@@ -1,4 +1,5 @@
 import fixture from 'can-fixture';
+import Restaurant from '../restaurant';
 
 const store = fixture.store([{
   _id: 1,
@@ -26,21 +27,8 @@ const store = fixture.store([{
     owner: "node_modules/place-my-order-assets/images/3-owner.jpg",
     thumbnail: "node_modules/place-my-order-assets/images/2-thumbnail.jpg"
   }
-}],{
-  "address.city": function(restaurantValue, paramValue, restaurant){
-    return restaurant.address.city === paramValue;
-  },
-  "address.state": function(restaurantValue, paramValue, restaurant){
-    return restaurant.address.state === paramValue;
-  }
-});
+}], Restaurant.connection.algebra);
 
-fixture({
-  'GET /api/restaurants': store.findAll,
-  'GET /api/restaurants/{id}': store.findOne,
-  'POST /api/restaurants': store.create,
-  'PUT /api/restaurants/{id}': store.update,
-  'DELETE /api/restaurants/{id}': store.destroy
-});
+fixture('/api/restaurants/{_id}', store);
 
 export default store;

--- a/guides/place-my-order/steps/create-test/restaurants_model.js
+++ b/guides/place-my-order/steps/create-test/restaurants_model.js
@@ -1,0 +1,37 @@
+import DefineMap from 'can-define/map/';
+import DefineList from 'can-define/list/';
+import set from 'can-set';
+import superMap from 'can-connect/can/super-map/';
+import loader from '@loader';
+
+const Restaurant = DefineMap.extend({
+  seal: false
+}, {
+  '_id': '*'
+});
+
+const algebra = new set.Algebra(
+  set.props.id('_id'),
+  {
+    "address.city": function(restaurantValue, paramValue, restaurant){
+      return restaurant['address.city'] === restaurantValue;
+    },
+    "address.state": function(restaurantValue, paramValue, restaurant){
+      return restaurant['address.state'] === restaurantValue;
+    }
+  }
+);
+
+Restaurant.List = DefineList.extend({
+  '*': Restaurant
+});
+
+Restaurant.connection = superMap({
+  url: loader.serviceBaseURL + '/api/restaurants',
+  Map: Restaurant,
+  List: Restaurant.List,
+  name: 'restaurant',
+  algebra
+});
+
+export default Restaurant;

--- a/guides/place-my-order/steps/create-test/states.js
+++ b/guides/place-my-order/steps/create-test/states.js
@@ -1,16 +1,11 @@
 import fixture from 'can-fixture';
+import State from '../state';
 
 const store = fixture.store([
   { name: 'Calisota', short: 'CA' },
   { name: 'New Troy', short: 'NT'}
-],{});
+], State.connection.algebra);
 
-fixture({
-  'GET /api/states': store.findAll,
-  'GET /api/states/{short}': store.findOne,
-  'POST /api/states': store.create,
-  'PUT /api/states/{short}': store.update,
-  'DELETE /api/states/{short}': store.destroy
-});
+fixture('/api/states/{short}', store);
 
 export default store;

--- a/guides/place-my-order/test.js
+++ b/guides/place-my-order/test.js
@@ -259,6 +259,10 @@ guide.step("Create a test", function(){
 													 join(__dirname, "steps", "create-test", "restaurants.js"));
 		})
 		.then(function(){
+			return guide.replaceFile(join("src", "models", "restaurants.js"),
+													 join(__dirname, "steps", "create-test", "restaurants_model.js"));
+		})
+		.then(function(){
 			return guide.replaceFile(join("src", "restaurant", "list", "list_test.js"),
 													 join(__dirname, "steps", "create-test", "list_test.js"));
 


### PR DESCRIPTION
- use set.Algebra in superMap and fixture store
- use getList instead of findAll
- don't use can-connect/can/tag/ by default
- add can-connect/can/tag/ for order model

Closes https://github.com/donejs/donejs/issues/633.
Closes https://github.com/donejs/donejs/issues/803.
