### PR TITLE
Mention the contribution guide on the community page

### DIFF
--- a/docs/community.mustache
+++ b/docs/community.mustache
@@ -280,11 +280,10 @@
             <a id="maintainable"></a>
             <h1><span class="heavy">Contribute</span> <span class="light">to</span> <span class="heavy">Done</span><span class="light">JS</span></h1>
             <p>
-              Help contribute to the core DoneJS project. <a href="https://github.com/donejs/donejs/issues">Create an issue</a>, <br>resolve bugs or add new features. We want and need your help!
+              The <a href="./contributing.html">contribution guide</a> includes information about our code of conduct, reporting bugs, submitting new code, and more.
             </p>
-            <!-- <a href="" class="btn">Contribution Guide</a> -->
             <p>
-              (contribution guide coming soon)
+              We want and need your help!
             </p>
         </div>
     </div>


### PR DESCRIPTION
Forgot to remove the “contribution guide coming soon” paragraph. 😬
<img width="918" alt="screen shot 2017-02-16 at 9 28 23 am" src="https://cloud.githubusercontent.com/assets/10070176/23032731/4c1c6fda-f42a-11e6-884c-e1a1feb7912b.png">
