### PR TITLE
Update guides to show version numbers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm cache clean
+  - npm set registry http://registry.npmjs.org/
   - npm install
 
 # Post-install test scripts.

--- a/docs/guides/guide.md
+++ b/docs/guides/guide.md
@@ -23,7 +23,7 @@ In this section, we will install DoneJS and generate a new application.
 To get started, let's install the DoneJS command line utility globally:
 
 ```
-npm install -g donejs
+npm install -g donejs@0.9
 ```
 
 ### Generate the application
@@ -182,7 +182,7 @@ On the homepage, let's install and add [bit-tabs](https://github.com/bitovi-comp
 Run:
 
 ```
-npm install bit-tabs --save
+npm install bit-tabs@0.2 --save
 ```
 
 ### Update the page
@@ -332,7 +332,7 @@ When you deploy for the first time it will ask you to authorize, but first we ne
 Now we can add the Firebase deployment configuration to our `package.json` like this:
 
 ```
-donejs add firebase
+donejs add firebase@1
 ```
 
 When prompted, enter the name of the application created when you set up the Firebase app. Before you can deploy your app you need to login and authorize the Firebase tools, which you can do with:
@@ -386,7 +386,7 @@ Windows users should install the [Android Studio](https://developer.android.com/
 Now we can install the DoneJS Cordova tools with:
 
 ```
-donejs add cordova
+donejs add cordova@0.2
 ```
 
 Depending on your operating system you can accept most of the defaults, unless you would like to build for Android, which needs to be selected from the list of platforms.
@@ -408,7 +408,7 @@ Windows users will get instructions to download the latest version of the platfo
 To set up the desktop build, we have to add it to our application like this:
 
 ```
-donejs add nw
+donejs add nw@0.2
 ```
 
 We can answer most prompts with the default except for the version which needs to be set to the latest **stable version**. Set the version prompt to `0.12.3`.

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -27,7 +27,7 @@ You will need [NodeJS](http://nodejs.org) or [io.js](https://iojs.org/en/index.h
 To get started, let's install the DoneJS command line utility globally:
 
 ```
-npm install -g donejs
+npm install -g donejs@0.9
 ```
 
 Then we can create a new DoneJS application:
@@ -109,7 +109,7 @@ Single page applications usually communicate with a RESTful API and a websocket 
 **Note**: Kill the server for now while we install a few dependencies (ctrl+c on Windows and Mac).
 
 ```
-npm install place-my-order-api --save
+npm install place-my-order-api@0.4 --save
 ```
 
 Now we can add an API server start script into the `scripts` section of our `package.json` like this:
@@ -165,7 +165,7 @@ Go to [http://localhost:8080](http://localhost:8080) to see the "hello world" me
 Before we get to the code, we also need to install the `place-my-order-assets` package which contains the images and styles specifically for this tutorial's application:
 
 ```
-npm install place-my-order-assets --save
+npm install place-my-order-assets@0.1 --save
 ```
 
 Every DoneJS application consists of at least two files:
@@ -751,7 +751,7 @@ Here we are adding some more conditions if `page` is set to `restaurants`:
 The NPM integration of StealJS makes it very easy to share and import other components. One thing we want to do when showing the `pmo-order-new` component is have a tab to choose between the lunch and dinner menu. The good news is that there is already a [bit-tabs](https://github.com/bitovi-components/bit-tabs) component which does exactly that. Let's add it as a project dependency with:
 
 ```
-npm install bit-tabs --save
+npm install bit-tabs@0.2 --save
 ```
 
 And then integrate it into `src/order/new/new.stache`:
@@ -882,7 +882,7 @@ can-connect makes it very easy to implement real-time functionality. It is capab
 The `place-my-order-api` module uses the [Feathers](http://feathersjs.com/) NodeJS framework, which in addition to providing a REST API, sends those events in the form of a websocket event like `orders created`. To make the order page update in real-time, all we need to do is add listeners for those events to `src/models/order.js` and in the handler notify the order connection.
 
 ```
-npm install steal-socket.io --save
+npm install steal-socket.io@2 --save
 ```
 
 In `src/models/order.js` replace with:
@@ -979,7 +979,7 @@ Windows users should install the [Android Studio](https://developer.android.com/
 Now we can install the DoneJS Cordova tools with:
 
 ```
-donejs add cordova
+donejs add cordova@0.2
 ```
 
 Depending on your operating system you can accept most of the defaults, unless you would like to build for Android, which needs to be selected from the list of platforms.
@@ -1147,7 +1147,7 @@ If everything went well, we should see the emulator running our application.
 To set up the desktop build, we have to add it to our application like this:
 
 ```
-donejs add nw
+donejs add nw@0.2
 ```
 
 We can answer most prompts with the default except for the version which needs to be set to the latest **stable version**. Set the version prompt to `0.12.3`.
@@ -1241,7 +1241,7 @@ When you deploy for the first time it will ask you to authorize with your login 
 With the Firebase account and application in place we can add the deployment configuration to our project like this:
 
 ```
-donejs add firebase
+donejs add firebase@1
 ```
 
 When prompted, enter the name of the application created when you set up the Firebase app. Next, login to the firebase app for the first time by running:

--- a/guides/guide/test.js
+++ b/guides/guide/test.js
@@ -160,7 +160,7 @@ guide.step("Install and use bit-tabs", function(){
     return guide.wait(10000);
   }
 
-	return guide.executeCommand("npm", ["install", "bit-tabs", "--save"])
+	return guide.executeCommand("npm", ["install", "bit-tabs@0.2", "--save"])
     .then(installWait)
 		.then(function(){
 			return guide.replaceFile(join("src", "home.component"),
@@ -320,7 +320,7 @@ guide.stepIf("Desktop and mobile apps: Cordova", function() {
 }, function(){
 	return guide.executeCommand("npm", ["install", "-g", "ios-sim"])
 		.then(function(){
-			var proc = guide.answerPrompts("donejs", ["add", "cordova"]);
+			var proc = guide.answerPrompts("donejs", ["add", "cordova@0.2"]);
 			var answer = proc.answer;
 
 			answer(/Name of project/, "donejs chat\n");
@@ -340,7 +340,7 @@ guide.stepIf("Desktop and mobile apps: Cordova", function() {
 guide.stepIf("Desktop and mobile apps: NW.js", function() {
   return process.platform !== 'win32';
 }, function(){
-	var proc = guide.answerPrompts("donejs", ["add", "nw"]);
+	var proc = guide.answerPrompts("donejs", ["add", "nw@0.2"]);
 	var answer = proc.answer;
 
 	answer(/Main HTML file/, "\n");

--- a/guides/place-my-order/test.js
+++ b/guides/place-my-order/test.js
@@ -76,7 +76,7 @@ guide.step("Run NPM install", function() {
 
 
 guide.step("Install place-my-order-api", function() {
-	return guide.executeCommand("npm", ["install", "place-my-order-api"]);
+	return guide.executeCommand("npm", ["install", "place-my-order-api@0.4"]);
 });
 
 guide.step("Starting the application", function(){
@@ -110,7 +110,7 @@ guide.launchBrowser("http://localhost:8080");
  * Loading assets
  */
 guide.step("Loading assets", function(){
-	return guide.executeCommand("npm", ["install", "place-my-order-assets", "--save"])
+	return guide.executeCommand("npm", ["install", "place-my-order-assets@0.1", "--save"])
 		.then(wait)
 		.then(function(){
 			return guide.replaceFile(join("src", "index.stache"),
@@ -343,7 +343,7 @@ guide.step("Create additional components", function(){
 });
 
 guide.step("Importing other projects", function(){
-	return guide.executeCommand("npm", ["install", "bit-tabs", "--save"])
+	return guide.executeCommand("npm", ["install", "bit-tabs@0.2", "--save"])
 		.then(wait)
 		.then(wait)
 		.then(function(){
@@ -405,7 +405,7 @@ guide.closeBrowser();
  */
 guide.step("Set up a real-time connection", function(){
 	var replaceFile = guide.replaceFile;
-	return guide.executeCommand("npm", ["install", "steal-socket.io", "--save"])
+	return guide.executeCommand("npm", ["install", "steal-socket.io@2", "--save"])
 		.then(function(){
 			return replaceFile(join("src", "models", "order.js"),
 												 join(__dirname, "steps", "real-time", "order.js"));

--- a/guides/place-my-order/test.js
+++ b/guides/place-my-order/test.js
@@ -275,6 +275,7 @@ guide.launchBrowser("http://localhost:8080/src/restaurant/list/test.html");
 guide.test(function(){
 	return guide.functionalTest(join(__dirname, "steps", "create-test",
 																	 "test.js"))
+		.then(wait)
 		.then(wait);
 });
 
@@ -292,6 +293,7 @@ guide.step("Write the template", function(){
 		.then(function(){
 			return guide.injectSpy("src/restaurant/list/list.html");
 		})
+		.then(wait)
 		.then(wait);
 });
 
@@ -300,6 +302,7 @@ guide.launchBrowser("http://localhost:8080/src/restaurant/list/list.html");
 guide.test(function(){
 	return guide.functionalTest(join(__dirname, "steps", "write-template",
 																	 "test.js"))
+		.then(wait)
 		.then(wait);
 });
 
@@ -311,6 +314,7 @@ guide.step("Using a test runner", function(){
 		.then(function(){
 			return guide.executeCommand("donejs", ["test"]);
 		})
+		.then(wait)
 		.then(wait);
 });
 


### PR DESCRIPTION
This updates the guides to include the version numbers. This is to
ensure that the user installs the correct versions of things that is
compatible with DoneJS 0.9, so that in the future this guide will always
work.

Part of #855