### PR TITLE
Switch install tags to use @1

### DIFF
--- a/docs/guides/guide.md
+++ b/docs/guides/guide.md
@@ -31,7 +31,7 @@ In this section, we will install DoneJS and generate a new application.
 To get started, let's install the DoneJS command line utility globally:
 
 ```
-npm install -g donejs@alpha
+npm install -g donejs@1
 ```
 
 ### Generate the application
@@ -204,7 +204,7 @@ On the homepage, let's install and add [bit-tabs](https://github.com/bitovi-comp
 Run:
 
 ```
-npm install bit-tabs@alpha --save
+npm install bit-tabs@1 --save
 ```
 
 ### Update the page
@@ -454,7 +454,7 @@ Windows users should install the [Android Studio](https://developer.android.com/
 Now we can install the DoneJS Cordova tools with:
 
 ```
-donejs add cordova@alpha
+donejs add cordova@1
 ```
 
 Depending on your operating system you can accept most of the defaults, unless you would like to build for Android, which needs to be selected from the list of platforms.
@@ -476,7 +476,7 @@ Windows users will get instructions to download the latest version of the platfo
 To set up the desktop build, we have to add it to our application like this:
 
 ```
-donejs add electron
+donejs add electron@1
 ```
 
 Accept the default for all of the prompts.

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -29,7 +29,7 @@ You will need [NodeJS](http://nodejs.org) installed and your code editor of choi
 To get started, let's install the DoneJS command line utility globally:
 
 ```
-npm install -g donejs@alpha
+npm install -g donejs@1
 ```
 
 Then we can create a new DoneJS application:
@@ -724,7 +724,7 @@ Here we are adding some more conditions if `page` is set to `restaurants`:
 The NPM integration of StealJS makes it very easy to share and import other components. One thing we want to do when showing the `pmo-order-new` component is have a tab to choose between the lunch and dinner menu. The good news is that there is already a [bit-tabs](https://github.com/bitovi-components/bit-tabs) component which does exactly that. Let's add it as a project dependency with:
 
 ```
-npm install bit-tabs@alpha --save
+npm install bit-tabs@1 --save
 ```
 
 And then integrate it into `src/order/new/new.stache`:
@@ -1002,7 +1002,7 @@ Windows users should install the [Android Studio](https://developer.android.com/
 Now we can install the DoneJS Cordova tools with:
 
 ```
-donejs add cordova@alpha
+donejs add cordova@1
 ```
 
 Answer the question about the URL of the service layer with `http://www.place-my-order.com`.

--- a/guides/guide/test.js
+++ b/guides/guide/test.js
@@ -161,7 +161,7 @@ guide.step("Install and use bit-tabs", function(){
     return guide.wait(10000);
   }
 
-	return guide.executeCommand("npm", ["install", "bit-tabs@alpha", "--save"])
+	return guide.executeCommand("npm", ["install", "bit-tabs@1", "--save"])
     .then(installWait)
 		.then(function(){
 			return guide.replaceFile(join("src", "home.component"),

--- a/guides/place-my-order/test.js
+++ b/guides/place-my-order/test.js
@@ -352,7 +352,7 @@ guide.step("Create additional components", function(){
 });
 
 guide.step("Importing other projects", function(){
-	return guide.executeCommand("npm", ["install", "bit-tabs@alpha", "--save"])
+	return guide.executeCommand("npm", ["install", "bit-tabs@1", "--save"])
 		.then(wait)
 		.then(wait)
 		.then(function(){


### PR DESCRIPTION
Now that donejs@1.0.0 is released, this switches all of the guides to use `@1` instead of `@alpha`.

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
