### PR TITLE
Update binary location for npm link (old PR please ignore)

### DIFF
--- a/lib/cli/run-binary.js
+++ b/lib/cli/run-binary.js
@@ -8,11 +8,11 @@ module.exports = function(args, options, types) {
 
   return utils.projectRoot()
     .then(function(root) {
-      var doneScript = process.platform === 'win32' ? 'donejs.cmd' : 'donejs';
+      var doneScript = process.platform === 'win32' ? 'cli.cmd' : 'cli';
       var donejsBinary = path.join(root, 'node_modules', '.bin', doneScript);
 
       if (!fs.existsSync(donejsBinary)) {
-        var msg = 'Could not find local DoneJS binary (' + donejsBinary + ')';
+        var msg = 'Could not find local DoneJS CLI binary (' + donejsBinary + ')';
 
         if(args[0] === 'add') {
           msg += '\nAllowed types for a new project are: ' + (types || []).join(', ');


### PR DESCRIPTION
This is necessary to enable using npm link with donejs/cli, because
otherwise there is a conflict with bin/donejs.