### PR TITLE
donejs -> donejs-cli (for npm link)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Check out the [contribution guide on DoneJS.com](https://donejs.com/contributing
 	- [Speaking at a conference or meetup](https://donejs.com/contributing.html#speaking-at-a-conference-or-meetup)
 	- [Organizing a DoneJS meetup](https://donejs.com/contributing.html#organizing-a-donejs-meetup)
 
-## Usage with `donejs/cli`
+## Developing Locally with `donejs/cli`
 
 If you wish to develop both this project (`donejs/donejs`) and the CLI part (`donejs/cli`) in tandem, you may do so using `npm link`.
 
@@ -65,3 +65,24 @@ npm link donejs-cli && donejs add app
 ```
 
 In this way you, you can test your changes to the `donejs` and `donesj-cli` packages simultaneously.
+
+### Developing Locally with `donejs/generator-donejs`
+
+You can follow this logic to develop the previous two projects in tandem with the generator part (`donejs/generator-donejs`).
+
+Essentially, clone `donejs/generator-donejs`, `npm install`, `npm link`:
+
+```shell
+git clone https://github.com/donejs/generator-donejs.git
+cd generator-donejs && npm install && npm link
+```
+
+Now, in an empty directory, before you run any `donejs` command, link in the generator:
+
+```shell
+npm link generator-donejs && donejs add app
+```
+
+The app will be generated using your local version of the generator.
+
+Link in both `donejs-cli` and `generator-donejs` before running any `donejs` command to combine these.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,39 @@ Check out the [contribution guide on DoneJS.com](https://donejs.com/contributing
 	- [Writing a blog article](https://donejs.com/contributing.html#writing-a-blog-article)
 	- [Speaking at a conference or meetup](https://donejs.com/contributing.html#speaking-at-a-conference-or-meetup)
 	- [Organizing a DoneJS meetup](https://donejs.com/contributing.html#organizing-a-donejs-meetup)
+
+## Usage with `donejs/cli`
+
+If you wish to develop both this project (`donejs/donejs`) and the CLI part (`donejs/cli`) in tandem, you may do so using `npm link`.
+
+First, clone `donejs/donejs`:
+
+```shell
+git clone https://github.com/donejs/donejs.git
+```
+
+Next, clone `donejs/cli`:
+
+```shell
+https://github.com/donejs/cli.git
+```
+
+Now, in the cloned `donejs`, install the npm dependencies, and link it into npm:
+
+```shell
+cd donejs && npm install && npm link
+```
+
+Do the same in the cloned `cli`:
+
+```shell
+cd cli && npm install && npm link
+```
+
+Finally, you may now generate a DoneJS app that will use your locally linked `cli` and `donejs` like so:
+
+```shell
+npm link donejs-cli && donejs add app
+```
+
+In this way you, you can test your changes to the `donejs` and `donesj-cli` packages simultaneously.

--- a/lib/cli/cmd-init.js
+++ b/lib/cli/cmd-init.js
@@ -7,7 +7,9 @@ var mypkg = require(path.join(__dirname, '..', '..', 'package.json'));
 module.exports = function(folder, opts) {
   return utils.mkdirp(folder)
     .then(function(folderPath) {
-      var folderModules = path.join(folderPath, 'node_modules');
+      var linkedCli = false,
+        folderModules = path.join(folderPath, 'node_modules'),
+        folderCli = path.join(folderModules, 'donejs-cli');
 
       // create an empty node_modules inside the target `folder`, this
       // will prevent npm to install the dependencies in any node_modules
@@ -17,14 +19,22 @@ module.exports = function(folder, opts) {
       }
 
       console.log('Initializing new DoneJS application at', folderPath);
-      console.log('Installing donejs-cli');
 
-      if (!fs.existsSync(path.join(folderModules, 'donejs-cli'))) {
+      if (fs.existsSync(folderCli)) {
+        linkedCli = fs.lstatSync(folderCli).isSymbolicLink();
+      }
+
+      if (!linkedCli) {
+        console.log('Installing donejs-cli');
         return installCli(mypkg.version, { cwd: folderPath })
           .then(function() {
             return runCliInit(folderPath, opts);
           });
       } else {
+        // skip installing CLI when it exists as a symlink (it was probably put
+        // there by `npm link donejs-cli` for debug or development purposes)
+        // and npm@3 would wrongly "flatten" dependencies in the linked CLI.
+        console.log('Skip installing donejs-cli (already exists as symlink)');
         return runCliInit(folderPath, opts);
       }
     });

--- a/lib/cli/cmd-init.js
+++ b/lib/cli/cmd-init.js
@@ -19,10 +19,14 @@ module.exports = function(folder, opts) {
       console.log('Initializing new DoneJS application at', folderPath);
       console.log('Installing donejs-cli');
 
-      return installCli(mypkg.version, { cwd: folderPath })
-        .then(function() {
-          return runCliInit(folderPath, opts);
-        });
+      if (!fs.existsSync(path.join(folderModules, 'donejs-cli'))) {
+        return installCli(mypkg.version, { cwd: folderPath })
+          .then(function() {
+            return runCliInit(folderPath, opts);
+          });
+      } else {
+        return runCliInit(folderPath, opts);
+      }
     });
 };
 

--- a/lib/cli/run-binary.js
+++ b/lib/cli/run-binary.js
@@ -8,11 +8,17 @@ module.exports = function(args, options, types) {
 
   return utils.projectRoot()
     .then(function(root) {
-      var doneScript = process.platform === 'win32' ? 'donejs.cmd' : 'donejs';
+      var doneScript = process.platform === 'win32' ? 'donejs-cli.cmd' : 'donejs-cli';
       var donejsBinary = path.join(root, 'node_modules', '.bin', doneScript);
 
+      // backwards compatiblilty for bin/donejs before it became bin/donejs-cli
       if (!fs.existsSync(donejsBinary)) {
-        var msg = 'Could not find local DoneJS binary (' + donejsBinary + ')';
+        doneScript = process.platform === 'win32' ? 'donejs.cmd' : 'donejs';
+        donejsBinary = path.join(root, 'node_modules', '.bin', doneScript);
+      }
+
+      if (!fs.existsSync(donejsBinary)) {
+        var msg = 'Could not find local DoneJS CLI binary (' + donejsBinary + ')';
 
         if(args[0] === 'add') {
           msg += '\nAllowed types for a new project are: ' + (types || []).join(', ');

--- a/test/run-binary-test.js
+++ b/test/run-binary-test.js
@@ -54,7 +54,7 @@ describe('runBinary', function() {
       })
       .catch(function(err) {
         assert(
-          /Could not find local DoneJS/.test(err.message),
+          /Could not find local DoneJS CLI binary/.test(err.message),
           'it should reject with error'
         );
 
@@ -67,26 +67,35 @@ describe('runBinary', function() {
       });
   });
 
-  it('spawns process with provided arguments', function(done) {
-    var binaryPath;
+  describe('spawns a process with provided arguments', function() {
+    it('when the binary file is named `donejs`', function(done) {
+      spawnCreatedBinary('donejs', done);
+    });
+    it('when the binary file is named `donejs-cli`', function(done) {
+      spawnCreatedBinary('donejs-cli', done);
+    });
+  });
 
-    createDoneJSBinary()
-      .then(function(binary) {
-        binaryPath = binary;
+  function spawnCreatedBinary(binFile, done) {
+    var binPath;
+
+    createBinary(binFile)
+      .then(function(returnedPath) {
+        binPath = returnedPath;
         return runBinary(['--help']);
       })
       .then(function() {
         assert.equal(spawnCalls.length, 1, 'should spawn process');
         var call = spawnCalls[0];
 
-        assert.equal(call.binary, binaryPath);
+        assert.equal(call.binary, binPath);
         assert.deepEqual(call.args, ['--help']);
         assert.deepEqual(call.options, { cwd: root });
 
         done();
       })
       .catch(done);
-  });
+  }
 
   function deleteFolder() {
     if (fs.existsSync(root)) {
@@ -94,18 +103,18 @@ describe('runBinary', function() {
     }
   }
 
-  function createDoneJSBinary() {
-    var binary = path.join(root, 'node_modules', '.bin');
-    var doneScript = process.platform === 'win32' ? 'donejs.cmd' : 'donejs';
-    var binaryPath = path.join(binary, doneScript);
+  function createBinary(binFile) {
+    var binDir = path.join(root, 'node_modules', '.bin');
+    binFile = process.platform === 'win32' ? binFile+'.cmd' : binFile;
+    var binPath = path.join(binDir, binFile);
 
-    return utils.mkdirp(binary)
+    return utils.mkdirp(binDir)
       .then(function() {
         var writeFile = Q.denodeify(fs.writeFile);
-        return writeFile(binaryPath);
+        return writeFile(binPath);
       })
       .then(function() {
-        return binaryPath;
+        return binPath;
       });
   }
 });


### PR DESCRIPTION
Related to https://github.com/donejs/cli/pull/83

Once these two PRs are merged, it will be possible to do:

```
git clone -b rename-binary-for-npm-link-version --single-branch https://github.com/donejs/donejs.git && cd donejs && npm install && npm link

cd .. && git clone -b rename-binary-for-npm-link --single-branch  https://github.com/donejs/cli.git && cd cli && npm install && npm link

cd .. && mkdir fakeapp && cd fakeapp && npm link donejs-cli && donejs add app
```

If you try and do this without these PRs, `donejs/donejs` and `donejs/cli` will collide upon `npm link`, because they have the same binary file name of "donejs".

These PRs make the `donejs` binary be "donejs" and the `donejs-cli` binary be "donejs-cli".

So, these PRs enable local development by use of `npm link`, instead of having to [hack](https://github.com/donejs/developer-relations/issues/29) the [files](https://github.com/donejs/cli/pull/82#issuecomment-289615878).