### PR TITLE
Updated guide to use set.props.dotNotation

### DIFF
--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -387,7 +387,10 @@ We also need to specify that the restaurant list can be filtered to restaurants 
 @sourceref ../../guides/place-my-order/steps/create-test/restaurants_model.js
 @highlight 15-16
 
-Above we use 'set.props.dotNotation' since our queries for these nested properties will be in the MongoDB-style 'dot notation' format required by the backend.
+Above we use `set.props.dotNotation` since our queries for these nested properties will be in the [MongoDB-style 'dot notation'](https://docs.mongodb.com/v2.2/reference/glossary/#term-dot-notation) format required by the backend.
+
+For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the libraries underneath supermodel expect it to look like `{address:{state: 'IL'}}`. `can.set.dotNotation` allows supermodel to make comparisons these two formats.
+
 
 ### Test the connection
 

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -389,7 +389,7 @@ We also need to specify that the restaurant list can be filtered to restaurants 
 
 Above we use `set.props.dotNotation` since our queries for these nested properties will be in the [MongoDB-style 'dot notation'](https://docs.mongodb.com/v2.2/reference/glossary/#term-dot-notation) format required by the backend.
 
-For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the libraries underneath supermodel expect it to look like `{address:{state: 'IL'}}`. `can.set.dotNotation` allows supermodel to make comparisons these two formats.
+For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the libraries underneath supermodel expect it to look like `{address:{state: 'IL'}}`. `set.props.dotNotation` allows supermodel to make comparisons these two formats.
 
 
 ### Test the connection

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -389,7 +389,7 @@ We also need to specify that the restaurant list can be filtered to restaurants 
 
 Above we use `set.props.dotNotation` since our queries for these nested properties will be in the [MongoDB-style 'dot notation'](https://docs.mongodb.com/v2.2/reference/glossary/#term-dot-notation) format required by the backend.
 
-For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the libraries underneath supermodel expect it to look like `{address:{state: 'IL'}}`. `set.props.dotNotation` allows supermodel to make comparisons these two formats.
+For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the can-connect expect it to look like `{address:{state: 'IL'}}`. `set.props.dotNotation` allows can-connect to make comparisons between these two formats.
 
 
 ### Test the connection

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -389,7 +389,7 @@ We also need to specify that the restaurant list can be filtered to restaurants 
 
 Above we use `set.props.dotNotation` since our queries for these nested properties will be in the [MongoDB-style 'dot notation'](https://docs.mongodb.com/v2.2/reference/glossary/#term-dot-notation) format required by the backend.
 
-For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and the can-connect expect it to look like `{address:{state: 'IL'}}`. `set.props.dotNotation` allows can-connect to make comparisons between these two formats.
+For example, MongoDB expects a query parameter for restaurants in a specific state to look like `{'address.state':'IL'}` and can-connect expects it to look like `{address:{state: 'IL'}}`. `set.props.dotNotation` allows can-connect to make comparisons between these two formats.
 
 
 ### Test the connection

--- a/docs/guides/place-my-order.md
+++ b/docs/guides/place-my-order.md
@@ -382,6 +382,13 @@ We have now created a model and fixtures (for testing without an API) with a fol
 |   |   ├── test.js
 ```
 
+We also need to specify that the restaurant list can be filtered to restaurants in a queried city and state by updating `src/models/restaurants.js`:
+
+@sourceref ../../guides/place-my-order/steps/create-test/restaurants_model.js
+@highlight 15-16
+
+Above we use 'set.props.dotNotation' since our queries for these nested properties will be in the MongoDB-style 'dot notation' format required by the backend.
+
 ### Test the connection
 
 To test the connection you can run the following in the browser console. You can access the browser console by right clicking in the browser and selecting **Inspect**. Then switch to the **Console** tab if not already there. Test the connection with:
@@ -495,11 +502,6 @@ Update `src/models/fixtures/restaurants.js` to look like:
 
 @sourceref ../../guides/place-my-order/steps/create-test/restaurants.js
 @highlight 4-30
-
-And we also need to specify that the restaurant list should be filtered to only restaurants in the selected city and state by updating `src/models/restaurants.js`:
-
-@sourceref ../../guides/place-my-order/steps/create-test/restaurants_model.js
-@highlight 15-22
 
 #### Test the view model
 

--- a/guides/place-my-order/steps/create-test/list-test.js
+++ b/guides/place-my-order/steps/create-test/list-test.js
@@ -56,7 +56,8 @@ QUnit.asyncTest('setting state and city loads a list of its restaurants', functi
   vm.city = 'Alberny';
 
   vm.restaurants.then(restaurants => {
-    QUnit.deepEqual(restaurants.serialize(), expectedRestaurants, 'Got all restaurants');
+    QUnit.deepEqual(restaurants.serialize(), expectedRestaurants, 'Fetched restaurants equal to expected');
+    QUnit.deepEqual(restaurants.length, 1, 'Got expected number of restaurants');
     QUnit.start();
   });
 });

--- a/guides/place-my-order/steps/create-test/restaurants_model.js
+++ b/guides/place-my-order/steps/create-test/restaurants_model.js
@@ -12,14 +12,8 @@ const Restaurant = DefineMap.extend({
 
 const algebra = new set.Algebra(
   set.props.id('_id'),
-  {
-    "address.city": function(restaurantValue, paramValue, restaurant){
-      return restaurant['address.city'] === restaurantValue;
-    },
-    "address.state": function(restaurantValue, paramValue, restaurant){
-      return restaurant['address.state'] === restaurantValue;
-    }
-  }
+  set.props.dotNotation('address.state'),
+  set.props.dotNotation('address.city')
 );
 
 Restaurant.List = DefineList.extend({


### PR DESCRIPTION
Updates PMO guide to reflect changes in can-set stemming from #900
