### PR TITLE
Updates href for Blog link

### DIFF
--- a/docs/donejs.mustache
+++ b/docs/donejs.mustache
@@ -359,7 +359,7 @@
                 <h3><span class="heavy">Keep in Touch</span></h3>
                 <p><a href="https://twitter.com/donejs">Twitter</a></p>
                 <p><a href="https://www.youtube.com/channel/UC_HPFLeKzJNLOUnLc_3311Q/videos">Youtube</a></p>
-                <p><a href="http://blog.bitovi.com/category/open-source/">Blog</a></p>
+                <p><a href="https://www.bitovi.com/blog/topic/open-source">Blog</a></p>
 
             </div>
             <div class="col-sm-4">


### PR DESCRIPTION
Fixes #930.

Updates Blog link on donejs.com to point to the correct URL of the open-source topic on Bitovi's blog.
