### PR TITLE
Fixes #911. Adds 'new' as to create a new project

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -9,10 +9,18 @@ var help = require('./cmd-help');
 
 program.version(require('../../package.json').version);
 
+// donejs new
+program.command('new <type> [params...]')
+  .option('-S, --skip-install')
+  .usage(cmdAddNewUsage('new'))
+  .action(function(type, params, options) {
+    log(add(type, params, options));
+  });
+
 // donejs add
 program.command('add <type> [params...]')
   .option('-S, --skip-install')
-  .usage(cmdAddUsage())
+  .usage(cmdAddNewUsage('add'))
   .action(function(type, params, options) {
     log(add(type, params, options));
   });
@@ -33,12 +41,12 @@ program.command('*')
     runBinary(program.rawArgs.slice(2));
   });
 
-function cmdAddUsage() {
+function cmdAddNewUsage(cmd) {
   var usage =
     '[options] app [folder] \n' +
-    '\t add [options] plugin [folder] \n' +
-    '\t add [options] generator [name] \n' +
-    '\t add [options] <name> [params...] \n\n' +
+    '\t ' + cmd + ' [options] plugin [folder] \n' +
+    '\t ' + cmd + ' [options] generator [name] \n' +
+    '\t ' + cmd + ' [options] <name> [params...] \n\n' +
     '  Types: \n\n' +
     '    app,       Initializes a new app\n' +
     '    plugin,    Initializes a new plugin\n' +


### PR DESCRIPTION
@andrejewski Is right and I misread the issue.

`new` has been updated to be an alias for `add`.  Commander's `.alias` function was not used so that they appear to be the different commands with the same functionality.