### PR TITLE
Fixes #933. donejs help should no longer throw stack trace

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,4 +1,5 @@
 var program = require('commander');
+var Q = require('q');
 var log = require('../utils').log;
 var runBinary = require('./run-binary');
 
@@ -19,7 +20,10 @@ program.command('add <type> [params...]')
 program.command('help')
   .description('Show all DoneJS commands available for this application')
   .action(function() {
-    log(help());
+    log(help().catch(function(e) {
+      var msg = e.message + '\n' + program.helpInformation();
+      return Q.reject(new Error(msg));
+    }));
   });
 
 // donejs <anything else>

--- a/lib/cli/run-binary.js
+++ b/lib/cli/run-binary.js
@@ -12,10 +12,10 @@ module.exports = function(args, options, types) {
       var donejsBinary = path.join(root, 'node_modules', '.bin', doneScript);
 
       if (!fs.existsSync(donejsBinary)) {
-        var msg = 'Could not find local DoneJS binary (' + donejsBinary + ')';
+        var msg = '  Could not find local DoneJS binary (' + donejsBinary + ')';
 
         if(args[0] === 'add') {
-          msg += '\nAllowed types for a new project are: ' + (types || []).join(', ');
+          msg += '\n  Allowed types for a new project are: ' + (types || []).join(', ');
         }
 
         return Q.reject(new Error(msg));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,7 +82,7 @@ exports.log = function(promise) {
     })
     .catch(function(error) {
       console.log();
-      console.error(error.stack || error.message || error);
+      console.error(error.message || error);
       console.log();
 
       process.exit(1);


### PR DESCRIPTION
Fixes `donejs help` from throwing a stack trace.
