### PR TITLE
Updated route slug syntax in docs

### DIFF
--- a/docs/apis.md
+++ b/docs/apis.md
@@ -125,7 +125,7 @@ the chat application as an example in development.  We'll cover what happens whe
 1. A pushstate is triggered by user action, usually by clicking a link. [can-route](#canroute)'s routing rules determines the properties set on the application [viewModel](#canmap).
 
    ```
-   route(':page', { page: 'home' });
+   route('{page}', { page: 'home' });
    ```
 
 2. [done-autorender](#done-autorender) previously bound the AppViewModel to [can-route](#canroute) which causes any change in the route to be reflected in the AppMap instance.
@@ -1089,21 +1089,21 @@ The following sets the application ViewModel's `page` property
 to `"chat"` when the url looks like `/chat`:
 
 ```
-route(":page");
+route("{page}");
 ```
 
-You can define defaults that get set when `:page` is empty. The
+You can define defaults that get set when `{page}` is empty. The
 following sets the default `page` property to `"home"`.
 
 ```
-route(":page", { page: "home" });
+route("{page}", { page: "home" });
 ```
 
 You can specify multiple properties to set for a given url:
 
 ```
-route(":page/:slug");
-route(":page/:slug/:action");
+route("{page}/{slug}");
+route("{page}/{slug}/{action}");
 ```
 
 


### PR DESCRIPTION
From `:page` to `{page}`.

Related to canjs/canjs#3208