### PR TITLE
Remove `npm cache clean` from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 publish-docs:
-	npm cache clean
 	rm -rf node_modules
 	npm install
 	npm run document:force


### PR DESCRIPTION
As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid.