### PR TITLE
Don’t create a package-lock.json file when installing the CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
 - 4
 - 6
 - 7
+- 8
 notifications:
   slack:
     secure: TAq0S0FA/OXtLjmIlJsytzz5WMB5L2QEedW7q+rAhKHg+w9FXOkE9guP72yLe92hKLMAsitD4OSACOtIR3QSSGNden/eKYQEVikCeNKOIO/FoHOrPTkXHfW1/2ihIvOBF2NaEvIGZsjwr12wIewSSM5VrdKwl1skgd0K7CoY/Uw=

--- a/lib/cli/cmd-init.js
+++ b/lib/cli/cmd-init.js
@@ -29,7 +29,7 @@ module.exports = function(folder, opts) {
 // install donejs-cli
 function installCli(version, options) {
   var pkg = 'donejs-cli@' + utils.versionRange(version);
-  var npmArgs = [ 'install', pkg, '--loglevel', 'error' ];
+  var npmArgs = [ 'install', pkg, '--no-package-lock', '--loglevel', 'error' ];
   return utils.spawn('npm', npmArgs, options);
 }
 

--- a/test/cmd-init-test.js
+++ b/test/cmd-init-test.js
@@ -89,7 +89,7 @@ describe('cli init cmd', function() {
 
         assert.equal(installCliCall.binary, 'npm');
         assert.deepEqual(installCliCall.args, [
-          'install', 'donejs-cli@latest', '--loglevel', 'error'
+          'install', 'donejs-cli@latest', '--no-package-lock', '--loglevel', 'error'
         ]);
 
         assert.deepEqual(runBinaryCall.args, ['init']);
@@ -121,4 +121,3 @@ describe('cli init cmd', function() {
     }
   }
 });
-


### PR DESCRIPTION
Should fix https://github.com/donejs/donejs/issues/959. I’m submitting this against the [patch branch](https://github.com/donejs/donejs/tree/patch) so I can test a pre-release after this is merged.