### PR TITLE
Fix tests running in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: false
+sudo: required
 language: node_js
-dist: precise
+dist: trusty
 addons:
   firefox: "51.0"
 before_install:
@@ -22,6 +22,7 @@ notifications:
     on_success: change
     on_failure: change
 script:
+  - sudo sh -c 'dbus-uuidgen > /etc/machine-id'
   - npm run jshint
   - npm run document
   - npm run test-guides

--- a/guides/place-my-order/test.js
+++ b/guides/place-my-order/test.js
@@ -263,7 +263,7 @@ guide.step("Create a test", function(){
 													 join(__dirname, "steps", "create-test", "restaurants.js"));
 		})
 		.then(function(){
-			return guide.replaceFile(join("src", "models", "restaurants.js"),
+			return guide.replaceFile(join("src", "models", "restaurant.js"),
 													 join(__dirname, "steps", "create-test", "restaurants_model.js"));
 		})
 		.then(function(){

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "coveralls-send": "0.0.2",
     "dotdotdot": "^1.7.0",
     "es6-promise": "^4.1.0",
-    "guide-automation": "^0.3.4",
+    "guide-automation": "^0.3.11",
     "is-appveyor": "^1.0.0",
     "istanbul": "^0.4.2",
     "jshint": "^2.8.0",


### PR DESCRIPTION
This fixes tests running in Travis. For some reason dbus needs
`/etc/machine-id` and Travis doesn't create one, so need to run a sudo
command to generate it. This stuff is a bit over my head, but it works.
Closes #1023

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
