### PR TITLE
Add package config

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,22 @@
       "bit-docs-tag-sourceref": "^0.0.3",
       "bit-docs-tag-package": "^0.0.3",
       "bit-docs-process-mustache": "^0.0.1",
-      "bit-docs-generate-html": "^0.3.6",
+      "bit-docs-generate-html": "^0.8.0",
       "bit-docs-prettify": "^0.1.0",
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-tag-demo": "^0.3.0",
       "bit-docs-html-toc": "^0.6.2",
-      "bit-docs-donejs-theme": "^1.2.2"
+      "bit-docs-donejs-theme": "^2.0.0"
+    },
+    "html": {
+      "package": {
+        "steal": {
+          "plugins": [
+            "steal-less",
+            "can"
+          ]
+        }
+      }
     },
     "glob": {
       "pattern": "docs/**/*.{md,mustache}"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-tag-demo": "^0.3.0",
       "bit-docs-html-toc": "^0.6.2",
-      "bit-docs-donejs-theme": "^2.0.0"
+      "bit-docs-donejs-theme": "^1.2.2"
     },
     "html": {
       "package": {


### PR DESCRIPTION
This allows using the newest versions of `bit-docs-generate-html` without errors.

Updating `bit-docs-generate-html` allows `assign` to be removed in `bit-docs-donejs-theme`:

https://github.com/donejs/bit-docs-donejs-theme/pull/66