### PR TITLE
Use pre-releases of bit-docs plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/donejs/donejs",
   "devDependencies": {
-    "bit-docs": "0.0.7",
+    "bit-docs": "pre",
     "coveralls-send": "0.0.2",
     "dotdotdot": "^1.7.0",
     "es6-promise": "^4.1.0",
@@ -66,17 +66,17 @@
   },
   "bit-docs": {
     "dependencies": {
-      "bit-docs-glob-finder": "^0.0.5",
-      "bit-docs-dev": "^0.0.3",
-      "bit-docs-js": "^0.0.6",
-      "bit-docs-tag-sourceref": "^0.0.3",
-      "bit-docs-tag-package": "^0.0.3",
-      "bit-docs-process-mustache": "^0.0.1",
-      "bit-docs-generate-html": "^0.8.0",
-      "bit-docs-prettify": "^0.1.0",
-      "bit-docs-html-highlight-line": "^0.2.2",
-      "bit-docs-tag-demo": "^0.3.0",
-      "bit-docs-html-toc": "^0.6.2",
+      "bit-docs-glob-finder": "pre",
+      "bit-docs-dev": "pre",
+      "bit-docs-js": "pre",
+      "bit-docs-tag-sourceref": "pre",
+      "bit-docs-tag-package": "pre",
+      "bit-docs-process-mustache": "pre",
+      "bit-docs-generate-html": "pre",
+      "bit-docs-prettify": "pre",
+      "bit-docs-html-highlight-line": "pre",
+      "bit-docs-tag-demo": "pre",
+      "bit-docs-html-toc": "pre",
       "bit-docs-donejs-theme": "^1.2.2"
     },
     "html": {


### PR DESCRIPTION
~~Surprisingly it looks like everything still works using the bleeding edge of bit-docs plugins.~~
**NOTE**: Looks like there are rendering errors with the generated site: #1032 

Watch it build without errors here: https://asciinema.org/a/lOMVznpstVqBtoMJ15rrLxxW6

Don't merge this until `pre` versions have been updated to actual version ranges (after all current `pre`-release bit-docs plugins are fully released).