### PR TITLE
Add the donejs upgrade command

### DIFF
--- a/lib/cli/cmd-upgrade.js
+++ b/lib/cli/cmd-upgrade.js
@@ -1,0 +1,111 @@
+var utils = require("../utils");
+var runBinary = require('./run-binary');
+var spawn = require('cross-spawn-async');
+var donejsVersion = require('../../package.json').version;
+
+// Maps donejs versions to canjs versions
+var canjsVersionMap = {
+  "2": "4"
+};
+
+module.exports = function(version, options) {
+  var requestedVersion = version || utils.versionRange(donejsVersion);
+
+  var packageJsonPromise = rootPackageJson();
+  var donejscliPackageJsonPromise = getDonejsCliPackageForRange(requestedVersion);
+
+  return Promise.all([ donejscliPackageJsonPromise, packageJsonPromise ])
+  .then(function(results){
+    var cliPkg = results[0];
+    var handle = results[1];
+
+    var donejs = cliPkg.donejs;
+
+    var pkg = handle.get();
+
+    Object.assign(pkg.dependencies, donejs.dependencies);
+    Object.assign(pkg.devDependencies, donejs.devDependencies);
+
+    handle.write(pkg);
+
+    // Run npm install to get the newest versions
+    return utils.spawn("npm", ["install"]);
+  })
+  .then(function(){
+    if(options.canmigrate) {
+      return installCanMigrate()
+      .then(function(){
+        return runCanMigrate(requestedVersion);
+      });
+    }
+  });
+};
+
+function rootPackageJson() {
+  return utils.projectRoot().then(function(root){
+    var packagePath = root + "/package.json";
+    return {
+      get: function(){
+        return require(packagePath);
+      },
+      write: function(newPackage){
+        var json = JSON.stringify(newPackage, null, " ");
+        require("fs").writeFileSync(packagePath, json, "utf8");
+      }
+    };
+  });
+}
+
+function getDonejsCliPackageForRange(versionRange) {
+  return new Promise(function(resolve, reject){
+    var child = spawn("npm", ["info", "--json", "donejs-cli@" + versionRange]);
+    var json = "";
+    child.stdout.on("data", function(data){
+      json += data.toString();
+    });
+    child.on("exit", function(status){
+      if(status === 1) {
+        reject();
+      } else {
+        try {
+          var data = JSON.parse(json);
+          resolve(data[data.length - 1] || data);
+        } catch(err) {
+          reject(err);
+        }
+      }
+    });
+  });
+}
+
+function installCanMigrate() {
+  return utils.spawn("npm", ["install", "--no-save", "can-migrate"]);
+}
+
+function runCanMigrate(requestedDonejsVersion) {
+  var donejsMajor = getMajorVersion(requestedDonejsVersion) ||
+    getMajorVersion(donejsVersion);
+  var canjsVersion = canjsVersionMap[donejsMajor];
+  if(canjsVersion) {
+    return runBinary(["can-migrate", "--apply", "--can-version", canjsVersion.toString()]);
+  }
+  return Promise.resolve();
+}
+
+function getMajorVersion(versionRange) {
+  var index = 0, len = versionRange.length;
+  var numExp = /[1-9]/;
+  var vers = "";
+  while(index < versionRange.length) {
+    var char = versionRange[index];
+    if(numExp.test(char)) {
+      vers += char;
+    }
+    // Break the first time we get a non-number after having gotten at least one
+    else if(vers.length) {
+      break;
+    }
+    index++;
+  }
+  return vers;
+}

--- a/lib/cli/cmd-upgrade.js
+++ b/lib/cli/cmd-upgrade.js
@@ -1,7 +1,7 @@
 var utils = require("../utils");
-var runBinary = require('./run-binary');
 var spawn = require('cross-spawn-async');
 var donejsVersion = require('../../package.json').version;
+var path = require("path");
 
 // Maps donejs versions to canjs versions
 var canjsVersionMap = {
@@ -20,6 +20,7 @@ module.exports = function(version, options) {
     var handle = results[1];
 
     var donejs = cliPkg.donejs;
+    var projectRoot = handle.root;
 
     var pkg = handle.get();
 
@@ -29,13 +30,15 @@ module.exports = function(version, options) {
     handle.write(pkg);
 
     // Run npm install to get the newest versions
-    return utils.spawn("npm", ["install"]);
+    return utils.spawn("npm", ["install"]).then(function(){
+      return projectRoot;
+    });
   })
-  .then(function(){
+  .then(function(projectRoot){
     if(options.canmigrate) {
       return installCanMigrate()
       .then(function(){
-        return runCanMigrate(requestedVersion);
+        return runCanMigrate(projectRoot, requestedVersion);
       });
     }
   });
@@ -43,8 +46,9 @@ module.exports = function(version, options) {
 
 function rootPackageJson() {
   return utils.projectRoot().then(function(root){
-    var packagePath = root + "/package.json";
+    var packagePath = path.join(root, "package.json");
     return {
+      root: root,
       get: function(){
         return require(packagePath);
       },
@@ -82,12 +86,15 @@ function installCanMigrate() {
   return utils.spawn("npm", ["install", "--no-save", "can-migrate"]);
 }
 
-function runCanMigrate(requestedDonejsVersion) {
+function runCanMigrate(projectRoot, requestedDonejsVersion) {
   var donejsMajor = getMajorVersion(requestedDonejsVersion) ||
     getMajorVersion(donejsVersion);
   var canjsVersion = canjsVersionMap[donejsMajor];
   if(canjsVersion) {
-    return runBinary(["can-migrate", "--apply", "--can-version", canjsVersion.toString()]);
+    var canMigratePath = path.join(projectRoot, 'node_modules', '.bin', "can-migrate");
+    var args = [canMigratePath, "**/*.*", "--apply", "--can-version",
+      canjsVersion.toString(), "--force"];
+    return utils.spawn("node", args);
   }
   return Promise.resolve();
 }
@@ -96,7 +103,7 @@ function getMajorVersion(versionRange) {
   var index = 0, len = versionRange.length;
   var numExp = /[1-9]/;
   var vers = "";
-  while(index < versionRange.length) {
+  while(index < len) {
     var char = versionRange[index];
     if(numExp.test(char)) {
       vers += char;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -19,7 +19,8 @@ program.command('add <type> [params...]')
   });
 
 program.command('upgrade [version]')
-  .option('--no-canmigrate')
+  .description('Upgrade the current project to the latest DoneJS version')
+  .option('--no-canmigrate', 'Skip running can-migrate')
   .action(function(version, options) {
     log(upgrade(version, options));
   });

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -6,6 +6,7 @@ var runBinary = require('./run-binary');
 // commands
 var add = require('./cmd-add');
 var help = require('./cmd-help');
+var upgrade = require('./cmd-upgrade');
 
 program.version(require('../../package.json').version);
 
@@ -15,6 +16,12 @@ program.command('add <type> [params...]')
   .usage(cmdAddUsage())
   .action(function(type, params, options) {
     log(add(type, params, options));
+  });
+
+program.command('upgrade [version]')
+  .option('--no-canmigrate')
+  .action(function(version, options) {
+    log(upgrade(version, options));
   });
 
 program.command('help')

--- a/test/cmd-upgrade-test.js
+++ b/test/cmd-upgrade-test.js
@@ -1,6 +1,5 @@
 var Q = require('q');
 var fs = require('fs');
-var path = require('path');
 var rimraf = require('rimraf');
 var assert = require('assert');
 var mockery = require('mockery');
@@ -10,6 +9,7 @@ describe('cli upgrade cmd', function() {
   var cwd;
   var upgrade;
   var spawnCalls;
+  var writeCalls;
   var runBinaryCall;
   var folder = 'test-project';
   var cmdUpgradePath = '../lib/cli/cmd-upgrade';

--- a/test/cmd-upgrade-test.js
+++ b/test/cmd-upgrade-test.js
@@ -1,0 +1,141 @@
+var Q = require('q');
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
+var assert = require('assert');
+var mockery = require('mockery');
+var utils = require('../lib/utils');
+
+describe('cli upgrade cmd', function() {
+  var cwd;
+  var upgrade;
+  var spawnCalls;
+  var runBinaryCall;
+  var folder = 'test-project';
+  var cmdUpgradePath = '../lib/cli/cmd-upgrade';
+  var pkgJsonPath = __dirname + '/../test-project/package.json';
+
+  beforeEach(function() {
+    spawnCalls = [];
+    writeCalls = [];
+    runBinaryCall = {};
+    cwd = process.cwd();
+
+    deleteFolder();
+
+    mockery.enable({
+      useCleanCache: true,
+      warnOnUnregistered: false
+    });
+
+    mockery.registerAllowable(cmdUpgradePath);
+
+    mockery.registerMock('./run-binary', function() {
+      runBinaryCall.args = arguments[0];
+      runBinaryCall.options = arguments[1];
+    });
+
+    mockery.registerMock('../utils', {
+      mkdirp: utils.mkdirp,
+      versionRange: function() { return 'latest'; },
+      projectRoot: function(){
+        return Promise.resolve(__dirname + '/../' + folder);
+      },
+      spawn: function() {
+        spawnCalls.push({
+          binary: arguments[0],
+          args: arguments[1],
+          options: arguments[2]
+        });
+        return Q(true);
+      }
+    });
+
+    mockery.registerMock(pkgJsonPath, {
+      dependencies: {
+        foo: "1.0.0"
+      },
+      devDependencies: {
+        bar: "1.0.0"
+      }
+    });
+
+    mockery.registerMock('fs', {
+      writeFileSync: function(path, data, enc){
+        writeCalls.push({ path, data, enc });
+      }
+    });
+
+    mockery.registerMock('cross-spawn-async', function(){
+      spawnCalls.push({
+        binary: arguments[0],
+        args: arguments[1],
+        options: arguments[2]
+      });
+      var makeOn = function() {
+        var fn = function(ev, cb) {
+          fn.cb = cb;
+        };
+        return fn;
+      };
+      var onData = makeOn();
+      var onExit = makeOn();
+      var mock = {stdout: { on: onData }, on: onExit};
+
+      setTimeout(function(){
+        var pkg = {donejs: {dependencies: {foo: "2.0.0"}, devDependencies: {bar: "2.0.0"}}};
+        onData.cb(JSON.stringify(pkg));
+        setTimeout(function() { onExit.cb(0); }, 20);
+      }, 20);
+
+      return mock;
+    });
+
+    upgrade = require(cmdUpgradePath);
+  });
+
+  afterEach(function() {
+    deleteFolder();
+    mockery.disable();
+    mockery.deregisterAll();
+  });
+
+  it('updates the package.json', function(done){
+    upgrade(null, {canmigrate: false})
+      .then(function(){
+        assert.equal(writeCalls.length, 1);
+        assert.equal(writeCalls[0].path, pkgJsonPath);
+
+        var json = JSON.parse(writeCalls[0].data);
+        assert.equal(json.dependencies.foo, "2.0.0", "dependency is upgraded");
+        assert.equal(json.devDependencies.bar, "2.0.0", "devDependency is upgraded");
+
+        done();
+      })
+      .catch(done);
+  });
+
+  it('runs can-migrate', function(done){
+    upgrade(null, {canmigrate: true})
+      .then(function(){
+        assert.equal(runBinaryCall.args[0], "can-migrate", "ran can-migrate");
+        done();
+      })
+      .catch(done);
+  });
+
+  it('Does not run can-migrate when --no-canmigrate flag is passed', function(done){
+    upgrade(null, {canmigrate: false})
+      .then(function(){
+        assert.equal(runBinaryCall.args, undefined, "did not run can-migrate");
+        done();
+      })
+      .catch(done);
+  });
+
+  function deleteFolder() {
+    if (fs.existsSync(folder)) {
+      rimraf.sync(folder);
+    }
+  }
+});

--- a/test/cmd-upgrade-test.js
+++ b/test/cmd-upgrade-test.js
@@ -1,5 +1,6 @@
 var Q = require('q');
 var fs = require('fs');
+var path = require('path');
 var rimraf = require('rimraf');
 var assert = require('assert');
 var mockery = require('mockery');
@@ -10,15 +11,13 @@ describe('cli upgrade cmd', function() {
   var upgrade;
   var spawnCalls;
   var writeCalls;
-  var runBinaryCall;
   var folder = 'test-project';
   var cmdUpgradePath = '../lib/cli/cmd-upgrade';
-  var pkgJsonPath = __dirname + '/../test-project/package.json';
+  var pkgJsonPath = path.join(__dirname, "..", folder, "package.json");
 
   beforeEach(function() {
     spawnCalls = [];
     writeCalls = [];
-    runBinaryCall = {};
     cwd = process.cwd();
 
     deleteFolder();
@@ -29,11 +28,6 @@ describe('cli upgrade cmd', function() {
     });
 
     mockery.registerAllowable(cmdUpgradePath);
-
-    mockery.registerMock('./run-binary', function() {
-      runBinaryCall.args = arguments[0];
-      runBinaryCall.options = arguments[1];
-    });
 
     mockery.registerMock('../utils', {
       mkdirp: utils.mkdirp,
@@ -95,7 +89,7 @@ describe('cli upgrade cmd', function() {
   });
 
   afterEach(function() {
-    deleteFolder();
+    //deleteFolder();
     mockery.disable();
     mockery.deregisterAll();
   });
@@ -118,7 +112,8 @@ describe('cli upgrade cmd', function() {
   it('runs can-migrate', function(done){
     upgrade(null, {canmigrate: true})
       .then(function(){
-        assert.equal(runBinaryCall.args[0], "can-migrate", "ran can-migrate");
+        var lastCall = spawnCalls[spawnCalls.length - 1];
+        assert.ok(/can-migrate/.test(lastCall.args[0]), "ran can-migrate");
         done();
       })
       .catch(done);
@@ -127,7 +122,8 @@ describe('cli upgrade cmd', function() {
   it('Does not run can-migrate when --no-canmigrate flag is passed', function(done){
     upgrade(null, {canmigrate: false})
       .then(function(){
-        assert.equal(runBinaryCall.args, undefined, "did not run can-migrate");
+        var lastCall = spawnCalls[spawnCalls.length - 1];
+        assert.ok(!/can-migrate/.test(lastCall.args[0]), "did not run  can-migrate");
         done();
       })
       .catch(done);


### PR DESCRIPTION
This adds the `upgrade` command. This command has 2 pieces of
functionality:

* Updates the project's package.json file with the newest versions of all of the donejs projects (including canjs, stealjs, etc.).
* Runs can-migrate with the corresponding canjs version number. This
means that for donejs 2.0 it will run the canjs 4.0 codemods.

This should make the 2.0 migration guide much much easier.

Closes #535

<!--
Thanks for your contribution!

Please make sure your pull request (PR) includes documentation and/or test updates.

In this PR description, please include a link to the issue(s) your PR addresses. If you include the issue number(s) in your commit(s), GitHub can automatically close the original issue(s): https://help.github.com/articles/closing-issues-via-commit-messages/

If applicable, please include a screenshot or gif to demonstrate your change. This makes it easier for reviewers to verify that it works for them. You can use LICEcap to make a gif: http://www.cockos.com/licecap/
-->
