### PR TITLE
Switch to using the 'raw' binding in guides

### DIFF
--- a/guides/guide/steps/8-bit-tabs/home.component
+++ b/guides/guide/steps/8-bit-tabs/home.component
@@ -15,11 +15,11 @@
       <br>Chat
     </h1>
 
-    <bit-tabs tabsClass:from="'nav nav-tabs'">
-      <bit-panel title:from="'CanJS'">
+    <bit-tabs tabsClass:raw="nav nav-tabs">
+      <bit-panel title:raw="CanJS">
         <p>CanJS provides the MV*</p>
       </bit-panel>
-      <bit-panel title:from="'StealJS'">
+      <bit-panel title:raw="StealJS">
         <p>StealJS provides the infrastructure.</p>
       </bit-panel>
     </bit-tabs>

--- a/guides/place-my-order/steps/bit-tabs/new.stache
+++ b/guides/place-my-order/steps/bit-tabs/new.stache
@@ -2,11 +2,11 @@
 <div class="order-form">
   <h2>Order here</h2>
 
-  <bit-tabs tabsClass:from="'nav nav-tabs'">
-    <bit-panel title:from="'Lunch menu'">
+  <bit-tabs tabsClass:raw="nav nav-tabs">
+    <bit-panel title:raw="Lunch menu">
       This is the lunch menu
     </bit-panel>
-    <bit-panel title:from="'Dinner menu'">
+    <bit-panel title:raw="Dinner menu">
       This is the dinner menu
     </bit-panel>
   </bit-tabs>

--- a/guides/place-my-order/steps/create-data/new.stache
+++ b/guides/place-my-order/steps/create-data/new.stache
@@ -14,7 +14,7 @@
       <h3>Order from {{restaurant.name}}</h3>
 
       <form on:submit="placeOrder(scope.event)">
-        <bit-tabs tabsClass:from="'nav nav-tabs'">
+        <bit-tabs tabsClass:raw="nav nav-tabs">
           <p class="info {{^if(order.items.length)}}text-error{{else}}text-success{{/if}}">
             {{^if(order.items.length)}}
               Please choose an item
@@ -22,7 +22,7 @@
               {{order.items.length}} selected
             {{/if}}
           </p>
-          <bit-panel title:from="'Lunch menu'">
+          <bit-panel title:raw="Lunch menu">
             <ul class="list-group">
               {{#each(restaurant.menu.lunch)}}
                 <li class="list-group-item">
@@ -36,7 +36,7 @@
               {{/each}}
             </ul>
           </bit-panel>
-          <bit-panel title:from="'Dinner menu'">
+          <bit-panel title:raw="Dinner menu">
             <ul class="list-group">
               {{#each(restaurant.menu.dinner)}}
                 <li class="list-group-item">

--- a/guides/place-my-order/steps/real-time/history.component
+++ b/guides/place-my-order/steps/real-time/history.component
@@ -14,43 +14,43 @@
       <order-model get-list="{status='new'}">
         <pmo-order-list
           orders:from="."
-          list-title:from="'New Orders'"
-          status:from="'new'"
-          status-title:from="'New Order!''"
-          action:from="'preparing'"
-          action-title:from="'Preparing'"
-          empty-message:from="'No new orders'"/>
+          list-title:raw="New Orders"
+          status:raw="new"
+          status-title:raw="New Order!"
+          action:raw="preparing"
+          action-title:raw="Preparing"
+          empty-message:raw="No new orders"/>
       </order-model>
 
       <order-model get-list="{status='preparing'}">
         <pmo-order-list
           orders:from="."
-          list-title:from="'Preparing'"
-          status:from="'preparing'"
-          status-title:from="'Preparing'"
-          action:from="'delivery'"
-          action-title:from="'Out for delivery'"
-          empty-message:from="'No orders preparing'"/>
+          list-title:raw="Preparing"
+          status:raw="preparing"
+          status-title:raw="Preparing"
+          action:raw="delivery"
+          action-title:raw="Out for delivery"
+          empty-message:raw="No orders preparing"/>
       </order-model>
 
       <order-model get-list="{status='delivery'}">
         <pmo-order-list
           orders:from="."
-          list-title:from="'Out for delivery'"
-          status:from="'delivery'"
-          status-title:from="'Out for delivery'"
-          action:from="'delivered'"
-          action-title:from="'Delivered'"
-          empty-message:from="'No orders are being delivered'"/>
+          list-title:raw="Out for delivery"
+          status:raw="delivery"
+          status-title:raw="Out for delivery"
+          action:raw="delivered"
+          action-title:raw="Delivered"
+          empty-message:raw="No orders are being delivered"/>
       </order-model>
 
       <order-model get-list="{status='delivered'}">
         <pmo-order-list
           orders:from="."
-          list-title:from="'Delivered'"
-          status:from="'delivered'"
-          status-title:from="'Delivered'"
-          empty-message:from="'No delivered orders'"/>
+          list-title:raw="Delivered"
+          status:raw="delivered"
+          status-title:raw="Delivered"
+          empty-message:raw="No delivered orders"/>
       </order-model>
     </div>
   </view>


### PR DESCRIPTION
The guides, especially the PMO guide, had some use of the
`prop:from="'String value'"` binding. This PR switches it to use
`prop:raw="String value"` instead. Closes #1087
