### PR TITLE
Make donejs upgrade upgrade all can deps

### DIFF
--- a/lib/cli/cmd-upgrade.js
+++ b/lib/cli/cmd-upgrade.js
@@ -14,19 +14,50 @@ module.exports = function(version, options) {
 
   var packageJsonPromise = rootPackageJson();
   var donejscliPackageJsonPromise = getDonejsCliPackageForRange(requestedVersion);
+  var canPackageJsonPromise = donejscliPackageJsonPromise.then(function(cliPkg){
+    var canVersionRange = cliPkg.donejs.dependencies.can;
+    if(canVersionRange) {
+      return getCanPackageForRange(canVersionRange);
+    }
+  });
 
-  return Promise.all([ donejscliPackageJsonPromise, packageJsonPromise ])
+  return Promise.all([
+    donejscliPackageJsonPromise,
+    canPackageJsonPromise,
+    packageJsonPromise
+  ])
   .then(function(results){
     var cliPkg = results[0];
-    var handle = results[1];
+    var canPkg = results[1];
+    var handle = results[2];
 
     var donejs = cliPkg.donejs;
     var projectRoot = handle.root;
 
     var pkg = handle.get();
 
+    var dependsOnCan = pkg.dependencies.can;
+
     Object.assign(pkg.dependencies, donejs.dependencies);
     Object.assign(pkg.devDependencies, donejs.devDependencies);
+
+    if(!dependsOnCan) {
+      delete pkg.dependencies.can;
+    }
+
+    function addIfExists(obj, dep, vers) {
+      if(obj[dep]) {
+        obj[dep] = vers;
+      }
+    }
+
+    if(canPkg) {
+      Object.keys(canPkg.dependencies).forEach(function(dep) {
+        var vers = canPkg.dependencies[dep];
+        addIfExists(pkg.dependencies, dep, vers);
+        addIfExists(pkg.devDependencies, dep, vers);
+      });
+    }
 
     handle.write(pkg);
 
@@ -62,8 +93,16 @@ function rootPackageJson() {
 }
 
 function getDonejsCliPackageForRange(versionRange) {
+  return getPackage("donejs-cli@" + versionRange);
+}
+
+function getCanPackageForRange(versionRange) {
+  return getPackage("can@" + versionRange);
+}
+
+function getPackage(packageNameAndVersion) {
   return new Promise(function(resolve, reject){
-    var child = spawn("npm", ["info", "--json", "donejs-cli@" + versionRange]);
+    var child = spawn("npm", ["info", "--json", packageNameAndVersion]);
     var json = "";
     child.stdout.on("data", function(data){
       json += data.toString();


### PR DESCRIPTION
This makes it so that running `donejs upgrade` it will check the
compatible version of `can`'s package.json and update any depenencies
that you have therein.

This means if you depend on `can-stache` you'll get the correctly
upgraded version of can-stache. This is true for ecosystem packages as
well.

Closes #1132 and #1092