### PR TITLE
Remove redundant source from PMO

### DIFF
--- a/guides/place-my-order/steps/add-data/list.js
+++ b/guides/place-my-order/steps/add-data/list.js
@@ -38,24 +38,3 @@ const RestaurantList = Component.extend({
 
 export default RestaurantList;
 export const ViewModel = RestaurantList.ViewModel;
-
-
-import Component from 'can-component';
-import DefineMap from 'can-define/map/';
-import './list.less';
-import view from './list.stache';
-import Restaurant from '~/models/restaurant';
-
-export const ViewModel = DefineMap.extend({
-  restaurants: {
-    value() {
-      return Restaurant.getList({});
-    }
-  }
-});
-
-export default Component.extend({
-  tag: 'pmo-restaurant-list',
-  ViewModel,
-  view
-});


### PR DESCRIPTION
This removes the redundant source that was left over from the DoneJS 2
guide. Fixes #1156
