### PR TITLE
Handle creating folder structure for scoped projects

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,18 +13,22 @@ exports.mkdirp = function(folder) {
   var dfd = Q();
   var current = '';
 
-  parts.forEach(function(part) {
-    var myPath = path.join(current, part);
+  parts.forEach(function(part, index) {
+    // If we are using scoped names like "@bitovi/my-plugin"
+    // Only create the folder for "my-plugin" and exclude the scoping
+    if ((index === 0 && part.indexOf('@') === -1) || index > 0) {
+      var myPath = path.join(current, part);
+  
+      current = myPath;
+  
+      var resolve = function() {
+        return myPath;
+      };
 
-    current = myPath;
-
-    var resolve = function() {
-      return myPath;
-    };
-
-    dfd = dfd.then(function() {
-      return Q.nfcall(fs.mkdir, myPath).then(resolve, resolve);
-    });
+      dfd = dfd.then(function() {
+        return Q.nfcall(fs.mkdir, myPath).then(resolve, resolve);
+      });
+    }
   });
 
   return dfd.then(function(myPath) {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -23,6 +23,13 @@ describe('utils tests', function() {
         assert.equal(folderPath, process.cwd());
       });
   });
+  
+  it('mkdirp ignores scoped project name', function() {
+    return utils.mkdirp('@bitovi/test')
+      .then(function(folderPath) {
+        assert.equal(folderPath, path.join(process.cwd(), 'test'));
+      });
+  });
 
   it('spawns successfully', function(done) {
     var cwd = path.join(__dirname, '..');


### PR DESCRIPTION
This enables creating plugins with scoped names:
```bash
donejs add plugin @bitovi/my-plugin
```
will create a folder called `my-plugin`.

Ref - https://github.com/donejs/donejs/issues/1176