### PR TITLE
Use bit-calendar for upcoming events

### DIFF
--- a/docs/community.mustache
+++ b/docs/community.mustache
@@ -148,11 +148,29 @@
           </div>
       </div>
       <div class="inner-wrapper">
-      <div id="bithub-events-embed" class="col-sm-10 col-lg-9 center-block table-row">
-        <span class="pending-spinner"></span>
+      <div class="col-sm-10 col-lg-9 center-block table-row">
+        <calendar-events api-key="AIzaSyBsNpdGbkTsqn1BCSPQrjO9OaMySjK5Sns"
+                        calendar-id="jupiterjs.com_g27vck36nifbnqrgkctkoanqb4@group.calendar.google.com" 
+                        event-count="3">
+          <template>
+            <div class="upcoming-event">
+              <div class="event-description">
+                <div class="header">
+                  <h4 class='event-title'></h4>
+                  <p class='detail'>
+                    <span class='event-date'></span>
+                  </p>
+                </div>
+                <p class='event-body'></p>
+              </div>
+              <div class="footer">
+                <a class="event-url open-in-new" target="_blank">View Event</a>
+              </div>
+            </div>
+
+          </template>
+        </calendar-events>
       </div>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.11/moment-timezone-with-data.min.js"></script>
     </div>
 
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/donejs/donejs",
   "devDependencies": {
-    "bit-docs": "0.0.9",
+    "bit-docs": "0.2.0",
     "coveralls-send": "0.0.2",
     "dotdotdot": "^1.7.0",
     "es6-promise": "^4.1.0",
@@ -59,6 +59,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "cross-spawn-async": "^2.0.0",
+    "jquery": "^2.2.4",
     "q": "^1.4.1"
   },
   "directories": {
@@ -73,17 +74,18 @@
       "bit-docs-tag-package": "^0.0.3",
       "bit-docs-process-mustache": "^0.0.1",
       "bit-docs-generate-html": "^0.3.7",
-      "bit-docs-prettify": "^0.1.0",
+      "bit-docs-prettify": "^0.4.1",
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-tag-demo": "^0.3.0",
       "bit-docs-html-toc": "^0.6.2",
-      "bit-docs-donejs-theme": "^1.6.0"
+      "bit-docs-donejs-theme": "^1.6.0",
+      "@bitovi/calendar-events": "^0.0.8"
     },
     "glob": {
       "pattern": "docs/**/*.{md,mustache}"
     },
     "parent": "donejs",
-    "minifyBuild": true,
+    "minifyBuild": false,
     "dest": "./site"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "commander": "^2.8.1",
     "cross-spawn-async": "^2.0.0",
-    "jquery": "^2.2.4",
     "q": "^1.4.1"
   },
   "directories": {
@@ -78,7 +77,7 @@
       "bit-docs-html-highlight-line": "^0.2.2",
       "bit-docs-tag-demo": "^0.3.0",
       "bit-docs-html-toc": "^0.6.2",
-      "bit-docs-donejs-theme": "^1.6.0",
+      "bit-docs-donejs-theme": "^1.7.0",
       "@bitovi/calendar-events": "^0.0.8"
     },
     "glob": {


### PR DESCRIPTION
Using `https://github.com/bitovi/calendar-events` in `bit-docs-donejs-theme` in order to fix `Upcoming events` section:

<img width="909" alt="Screen Shot 2019-05-28 at 9 47 39 PM" src="https://user-images.githubusercontent.com/109013/58511895-ab8f9480-8193-11e9-9dc7-76bf1de5b394.png">
